### PR TITLE
v2.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Represents the **NuGet** versions.
 
 ## v2.3.7
-- *Fixed:* `SqlServerMigration` updated to correct the `DataResetFilterPredicate` to exclude all tables within schema `cdc`, and exclude all tables within the `dbo` schema where the table name starts with `sys`. This is to ensure that the internal Change Data tables are not reset, and that any SQL Server system tables are not inadvertantly reset.
+- *Fixed:* `SqlServerMigration` updated to correct the `DataResetFilterPredicate` to exclude all tables within schema `cdc`, and exclude all tables within the `dbo` schema where the table name starts with `sys`. This is to ensure that the internal Change Data tables are not reset, and that any SQL Server system tables are not inadvertently reset.
 
 ## v2.3.6
 - *Enhancement:* Updated `CoreEx` to version `3.3.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v2.3.7
+- *Fixed:* `SqlServerMigration` updated to correct the `DataResetFilterPredicate` to exclude all tables within schema `cdc`, and exclude all tables within the `dbo` schema where the table name starts with `sys`. This is to ensure that the internal Change Data tables are not reset, and that any SQL Server system tables are not inadvertantly reset.
+
 ## v2.3.6
 - *Enhancement:* Updated `CoreEx` to version `3.3.0`.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.3.6</Version>
+    <Version>2.3.7</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.SqlServer/Migration/SqlServerMigration.cs
+++ b/src/DbEx.SqlServer/Migration/SqlServerMigration.cs
@@ -101,7 +101,7 @@ namespace DbEx.SqlServer.Migration
 
         /// <inheritdoc/>
         protected override Func<DbTableSchema, bool> DataResetFilterPredicate => 
-            schema => !_resetBypass.Contains(schema.QualifiedName!) && schema.Schema != "cdc" && !(schema.Schema == "dbo" && schema.Name.StartsWith("sys"));
+            schema => !_resetBypass.Contains(schema.QualifiedName!) && schema.Schema != "sys" && schema.Schema != "cdc" && !(schema.Schema == "dbo" && schema.Name.StartsWith("sys"));
 
         /// <inheritdoc/>
         protected override async Task ExecuteScriptAsync(DatabaseMigrationScript script, CancellationToken cancellationToken = default)

--- a/src/DbEx/Migration/MigrationArgsBaseT.cs
+++ b/src/DbEx/Migration/MigrationArgsBaseT.cs
@@ -46,6 +46,16 @@ namespace DbEx.Migration
         public TSelf AddAssembly<TAssembly>() => AddAssembly(typeof(TAssembly));
 
         /// <summary>
+        /// Adds the <typeparamref name="TAssembly1"/> and <typeparamref name="TAssembly2"/> (being the underlying <see cref="Type.Assembly"/>) to <see cref="MigrationArgsBase.Assemblies"/>.
+        /// </summary>
+        public TSelf AddAssembly<TAssembly1, TAssembly2>() => AddAssembly(typeof(TAssembly1), typeof(TAssembly2));
+
+        /// <summary>
+        /// Adds the <typeparamref name="TAssembly1"/>, <typeparamref name="TAssembly2"/> and <typeparamref name="TAssembly3"/> (being the underlying <see cref="Type.Assembly"/>) to <see cref="MigrationArgsBase.Assemblies"/>.
+        /// </summary>
+        public TSelf AddAssembly<TAssembly1, TAssembly2, TAssembly3>() => AddAssembly(typeof(TAssembly1), typeof(TAssembly2), typeof(TAssembly3));
+
+        /// <summary>
         /// Adds a parameter to the <see cref="MigrationArgsBase.Parameters"/> where it does not already exist; unless <paramref name="overrideExisting"/> is selected then it will add or override.
         /// </summary>
         /// <param name="key">The parameter key.</param>


### PR DESCRIPTION
- *Fixed:* `SqlServerMigration` updated to correct the `DataResetFilterPredicate` to exclude all tables within schema `cdc`, and exclude all tables within the `dbo` schema where the table name starts with `sys`. This is to ensure that the internal Change Data tables are not reset, and that any SQL Server system tables are not inadvertently reset.