### PR TITLE
V2.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v2.3.8
+- *Fixed:* `SqlServerMigration` has been fixed to handling column size of `MAX` correctly.
+
 ## v2.3.7
 - *Fixed:* `SqlServerMigration` updated to correct the `DataResetFilterPredicate` to exclude all tables within schema `cdc`, and exclude all tables within the `dbo` schema where the table name starts with `sys`. This is to ensure that the internal Change Data tables are not reset, and that any SQL Server system tables are not inadvertently reset.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Represents the **NuGet** versions.
 
 ## v2.3.8
-- *Fixed:* `SqlServerMigration` has been fixed to handling column size of `MAX` correctly.
+- *Fixed:* `SqlServerMigration` has been fixed to handle column size of `MAX` correctly.
 
 ## v2.3.7
 - *Fixed:* `SqlServerMigration` updated to correct the `DataResetFilterPredicate` to exclude all tables within schema `cdc`, and exclude all tables within the `dbo` schema where the table name starts with `sys`. This is to ensure that the internal Change Data tables are not reset, and that any SQL Server system tables are not inadvertently reset.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.3.7</Version>
+    <Version>2.3.8</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/DbEx.MySql.csproj
+++ b/src/DbEx.MySql/DbEx.MySql.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <PackageReference Include="CoreEx.Database.MySql" Version="3.3.0" />
     <PackageReference Include="dbup-mysql" Version="5.0.10" />
-    <PackageReference Include="OnRamp" Version="1.0.7" />
+    <PackageReference Include="OnRamp" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DbEx.SqlServer/DbEx.SqlServer.csproj
+++ b/src/DbEx.SqlServer/DbEx.SqlServer.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.0" />
     <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
-    <PackageReference Include="OnRamp" Version="1.0.7" />
+    <PackageReference Include="OnRamp" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DbEx.SqlServer/SqlServerSchemaConfig.cs
+++ b/src/DbEx.SqlServer/SqlServerSchemaConfig.cs
@@ -73,7 +73,7 @@ namespace DbEx.SqlServer
         public override DbColumnSchema CreateColumnFromInformationSchema(DbTableSchema table, DatabaseRecord dr) => new(table, dr.GetValue<string>("COLUMN_NAME"), dr.GetValue<string>("DATA_TYPE"))
         {
             IsNullable = dr.GetValue<string>("IS_NULLABLE").ToUpperInvariant() == "YES",
-            Length = (ulong?)dr.GetValue<int?>("CHARACTER_MAXIMUM_LENGTH"),
+            Length = (ulong?)(dr.GetValue<int?>("CHARACTER_MAXIMUM_LENGTH") <= 0 ? null : dr.GetValue<int?>("CHARACTER_MAXIMUM_LENGTH")),
             Precision = (ulong?)(dr.GetValue<byte?>("NUMERIC_PRECISION") ?? dr.GetValue<short?>("DATETIME_PRECISION")),
             Scale = (ulong?)dr.GetValue<int?>("NUMERIC_SCALE"),
             DefaultValue = dr.GetValue<string>("COLUMN_DEFAULT")

--- a/src/DbEx/DbEx.csproj
+++ b/src/DbEx/DbEx.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="CoreEx.Database" Version="3.3.0" />
     <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
-    <PackageReference Include="OnRamp" Version="1.0.7" />
+    <PackageReference Include="OnRamp" Version="1.0.8" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tests/DbEx.Test.Console/Migrations/004-create-test-contact-table.sql
+++ b/tests/DbEx.Test.Console/Migrations/004-create-test-contact-table.sql
@@ -6,5 +6,6 @@
       [ContactTypeId] INT NOT NULL DEFAULT 1,
       [GenderId] INT NULL,
       [TenantId] NVARCHAR(50),
+      [Notes] NVARCHAR(MAX) NULL,
       CONSTRAINT [FK_Test_Contact_ContactType] FOREIGN KEY ([ContactTypeId]) REFERENCES [Test].[ContactType] ([ContactTypeId])
     )

--- a/tests/DbEx.Test.MySqlConsole/Migrations/004-create-test-contact-table.sql
+++ b/tests/DbEx.Test.MySqlConsole/Migrations/004-create-test-contact-table.sql
@@ -5,5 +5,6 @@
       `date_of_birth` DATE NULL,
       `contact_type_id` INT NOT NULL DEFAULT 1,
       `gender_id` INT NULL,
+      `notes` TEXT NULL,
       CONSTRAINT `FK_Test_Contact_ContactType` FOREIGN KEY (`contact_type_id`) REFERENCES `contact_type` (`contact_type_id`)
     )

--- a/tests/DbEx.Test/DatabaseSchemaTest.cs
+++ b/tests/DbEx.Test/DatabaseSchemaTest.cs
@@ -101,7 +101,7 @@ namespace DbEx.Test
             Assert.AreEqual("[Test].[Contact]", tab.QualifiedName);
             Assert.IsFalse(tab.IsAView);
             Assert.IsFalse(tab.IsRefData);
-            Assert.AreEqual(7, tab.Columns.Count);
+            Assert.AreEqual(8, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
 
             col = tab.Columns[0];
@@ -191,6 +191,24 @@ namespace DbEx.Test
 
             col = tab.Columns[6];
             Assert.AreEqual("TenantId", col.Name);
+
+            col = tab.Columns[7];
+            Assert.AreEqual("Notes", col.Name);
+            Assert.AreEqual("nvarchar", col.Type);
+            Assert.AreEqual("NVARCHAR(MAX) NULL", col.SqlType);
+            Assert.IsNull(col.Length);
+            Assert.IsNull(col.Scale);
+            Assert.IsNull(col.Precision);
+            Assert.AreEqual("string", col.DotNetType);
+            Assert.IsTrue(col.IsNullable);
+            Assert.IsFalse(col.IsPrimaryKey);
+            Assert.IsFalse(col.IsIdentity);
+            Assert.IsNull(col.IdentitySeed);
+            Assert.IsNull(col.IdentityIncrement);
+            Assert.IsFalse(col.IsUnique);
+            Assert.IsFalse(col.IsComputed);
+            Assert.IsFalse(col.IsForeignRefData);
+            Assert.IsNull(col.DefaultValue);
 
             // [Test].[MultiPk]
             tab = tables.Where(x => x.Name == "MultiPk").SingleOrDefault();
@@ -405,7 +423,7 @@ namespace DbEx.Test
             Assert.AreEqual("`contact`", tab.QualifiedName);
             Assert.IsFalse(tab.IsAView);
             Assert.IsFalse(tab.IsRefData);
-            Assert.AreEqual(6, tab.Columns.Count);
+            Assert.AreEqual(7, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
 
             col = tab.Columns[0];
@@ -491,6 +509,24 @@ namespace DbEx.Test
             Assert.AreEqual(string.Empty, col.ForeignSchema);
             Assert.AreEqual("gender", col.ForeignTable);
             Assert.AreEqual("gender_id", col.ForeignColumn);
+            Assert.IsNull(col.DefaultValue);
+
+            col = tab.Columns[6];
+            Assert.AreEqual("notes", col.Name);
+            Assert.AreEqual("text", col.Type);
+            Assert.AreEqual("TEXT NULL", col.SqlType);
+            Assert.AreEqual(65535, col.Length);
+            Assert.IsNull(col.Scale);
+            Assert.IsNull(col.Precision);
+            Assert.AreEqual("string", col.DotNetType);
+            Assert.IsTrue(col.IsNullable);
+            Assert.IsFalse(col.IsPrimaryKey);
+            Assert.IsFalse(col.IsIdentity);
+            Assert.IsNull(col.IdentitySeed);
+            Assert.IsNull(col.IdentityIncrement);
+            Assert.IsFalse(col.IsUnique);
+            Assert.IsFalse(col.IsComputed);
+            Assert.IsFalse(col.IsForeignRefData);
             Assert.IsNull(col.DefaultValue);
 
             // [Test].[MultiPk]

--- a/tests/DbEx.Test/DbEx.Test.csproj
+++ b/tests/DbEx.Test/DbEx.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">


### PR DESCRIPTION
- *Fixed:* `SqlServerMigration` has been fixed to handling column size of `MAX` correctly.