### PR TITLE
v2.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v2.3.9
+- *Fixed:* The YAML-based `MigrationCommand.Data` logic previously set the `CreatedBy`, `CreatedDate`, `UpdatedBy` and `UpdatedDate` (or specified equivalent) regardless of whether the data was being inserted or merged (insert/update). This has been corrected such that the appropriate values are only set for the specific type of operation being performed; i.e. `Created*`-only or `Updated*`-only.
+- *Fixed:* Enabled additional command-line arguments to be passed for `MigrationCommand.CodeGen` to enable inherited usage flexibility. Removed `MigrationArgsBase.ScriptName` and `MigrationArgsBase.ScriptArguments` and included within existing `MigrationArgsBase.Parameters` as singular dictionary of key/value pairs (simplification).
+
 ## v2.3.8
 - *Fixed:* `SqlServerMigration` has been fixed to handle column size of `MAX` correctly.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.3.8</Version>
+    <Version>2.3.9</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/MySqlSchemaConfig.cs
+++ b/src/DbEx.MySql/MySqlSchemaConfig.cs
@@ -67,6 +67,11 @@ namespace DbEx.MySql
                 dataParserArgs.RefDataColumnDefaults.TryAdd("is_active", _ => true);
                 dataParserArgs.RefDataColumnDefaults.TryAdd("sort_order", i => i);
             }
+
+            dataParserArgs.CreatedByColumnName ??= CreatedByColumnName;
+            dataParserArgs.CreatedDateColumnName ??= CreatedDateColumnName;
+            dataParserArgs.UpdatedByColumnName ??= UpdatedByColumnName;
+            dataParserArgs.UpdatedDateColumnName ??= UpdatedDateColumnName;
         }
 
         /// <inheritdoc/>

--- a/src/DbEx.MySql/Resources/DatabaseData_sql.hbs
+++ b/src/DbEx.MySql/Resources/DatabaseData_sql.hbs
@@ -1,12 +1,12 @@
 ﻿{{! Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx }}
 {{#if IsMerge}}
   {{#each Rows}}
-INSERT INTO `{{Table.Name}}` ({{#each Columns}}`{{Name}}`{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each Columns}}{{#if UseForeignKeyQueryForId}}(SELECT `{{DbColumn.ForeignColumn}}` FROM `{{DbColumn.ForeignTable}}` WHERE `{{DbColumn.ForeignRefDataCodeColumn}}` = {{{SqlValue}}} LIMIT 1){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}}) ON DUPLICATE KEY UPDATE {{#each Table.MergeUpdateColumns}}`{{Name}}` = VALUES(`{{Name}}`){{#unless @last}}, {{/unless}}{{/each}};
+INSERT INTO `{{Table.Name}}` ({{#each MergeInsertColumns}}`{{Name}}`{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each MergeInsertColumns}}{{#if UseForeignKeyQueryForId}}(SELECT `{{DbColumn.ForeignColumn}}` FROM `{{DbColumn.ForeignTable}}` WHERE `{{DbColumn.ForeignRefDataCodeColumn}}` = {{{SqlValue}}} LIMIT 1){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}}) ON DUPLICATE KEY UPDATE {{#each MergeUpdateColumns}}`{{Name}}` = {{{SqlValue}}}{{#unless @last}}, {{/unless}}{{/each}};
   {{/each}}
 SELECT {{Rows.Count}}; -- Total rows upserted
 {{else}}
   {{#each Rows}}
-INSERT INTO `{{Table.Name}}` ({{#each Columns}}`{{Name}}`{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each Columns}}{{#if UseForeignKeyQueryForId}}(SELECT `{{DbColumn.ForeignColumn}}` FROM `{{DbColumn.ForeignTable}}` WHERE `{{DbColumn.ForeignRefDataCodeColumn}}` = {{{SqlValue}}} LIMIT 1){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}});
+INSERT INTO `{{Table.Name}}` ({{#each InsertColumns}}`{{Name}}`{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each InsertColumns}}{{#if UseForeignKeyQueryForId}}(SELECT `{{DbColumn.ForeignColumn}}` FROM `{{DbColumn.ForeignTable}}` WHERE `{{DbColumn.ForeignRefDataCodeColumn}}` = {{{SqlValue}}} LIMIT 1){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}});
   {{/each}}
 SELECT {{Rows.Count}}; -- Total rows inserted
 {{/if}}

--- a/src/DbEx.SqlServer/Resources/DatabaseData_sql.hbs
+++ b/src/DbEx.SqlServer/Resources/DatabaseData_sql.hbs
@@ -18,14 +18,14 @@ MERGE INTO [{{Schema}}].[{{Name}}] WITH (HOLDLOCK) as [t]
       SELECT {{#each MergeMatchColumns}}[t].[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}})
     THEN UPDATE SET {{#each MergeUpdateColumns}}[t].[{{Name}}] = [s].[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}}
   WHEN NOT MATCHED BY TARGET
-    THEN INSERT ({{#each Columns}}[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}})
-      VALUES ({{#each Columns}}[s].[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}});
+    THEN INSERT ({{#each MergeInsertColumns}}[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}})
+      VALUES ({{#each MergeInsertColumns}}[s].[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}});
 
 SELECT @@ROWCOUNT
 DROP TABLE #temp
 {{else}}
   {{#each Rows}}
-INSERT INTO [{{Table.Schema}}].[{{Table.Name}}] ({{#each Columns}}[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each Columns}}{{#if UseForeignKeyQueryForId}}(SELECT TOP 1 [{{DbColumn.ForeignColumn}}] FROM [{{DbColumn.ForeignSchema}}].[{{DbColumn.ForeignTable}}] WHERE [{{DbColumn.ForeignRefDataCodeColumn}}] = {{{SqlValue}}}){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}})
+INSERT INTO [{{Table.Schema}}].[{{Table.Name}}] ({{#each InsertColumns}}[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each InsertColumns}}{{#if UseForeignKeyQueryForId}}(SELECT TOP 1 [{{DbColumn.ForeignColumn}}] FROM [{{DbColumn.ForeignSchema}}].[{{DbColumn.ForeignTable}}] WHERE [{{DbColumn.ForeignRefDataCodeColumn}}] = {{{SqlValue}}}){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}})
   {{/each}}
 SELECT {{Rows.Count}} -- Total rows inserted
 {{/if}}

--- a/src/DbEx.SqlServer/SqlServerSchemaConfig.cs
+++ b/src/DbEx.SqlServer/SqlServerSchemaConfig.cs
@@ -67,6 +67,11 @@ namespace DbEx.SqlServer
                 dataParserArgs.RefDataColumnDefaults.TryAdd("IsActive", _ => true);
                 dataParserArgs.RefDataColumnDefaults.TryAdd("SortOrder", i => i);
             }
+
+            dataParserArgs.CreatedByColumnName ??= CreatedByColumnName;
+            dataParserArgs.CreatedDateColumnName ??= CreatedDateColumnName;
+            dataParserArgs.UpdatedByColumnName ??= UpdatedByColumnName;
+            dataParserArgs.UpdatedDateColumnName ??= UpdatedDateColumnName;
         }
 
         /// <inheritdoc/>

--- a/src/DbEx/Console/MigrationConsoleBase.cs
+++ b/src/DbEx/Console/MigrationConsoleBase.cs
@@ -21,8 +21,8 @@ namespace DbEx.Console
     /// <summary>
     /// Base console that facilitates the <see cref="DatabaseMigrationBase"/> by managing the standard console command-line arguments/options.
     /// </summary>
-    /// <remarks>The standard console command-line arguments/options can be controlled via the constructor using the <see cref="SupportedOptions"/> flags. Additional capabilities can be added by inherting and overridding the
-    /// <see cref="OnBeforeExecute(CommandLineApplication)"/>, <see cref="OnValidation(ValidationContext)"/> and <see cref="OnMigrateAsync"/>. Changes to the console output can be achieved by overridding
+    /// <remarks>The standard console command-line arguments/options can be controlled via the constructor using the <see cref="SupportedOptions"/> flags. Additional capabilities can be added by inheriting and overriding the
+    /// <see cref="OnBeforeExecute(CommandLineApplication)"/>, <see cref="OnValidation(ValidationContext)"/> and <see cref="OnMigrateAsync"/>. Changes to the console output can be achieved by overriding
     /// <see cref="OnWriteMasthead"/>, <see cref="OnWriteHeader"/>, <see cref="OnWriteArgs(DatabaseMigrationBase)"/> and <see cref="OnWriteFooter(double)"/>.
     /// <para>The underlying command line parsing is provided by <see href="https://natemcmaster.github.io/CommandLineUtils/"/>.</para></remarks>
     public abstract class MigrationConsoleBase
@@ -160,20 +160,14 @@ namespace DbEx.Console
                 if (vr != ValidationResult.Success)
                     return vr;
 
-                if (_additionalArgs.Values.Count > 0 && !(Args.MigrationCommand.HasFlag(MigrationCommand.Script) || Args.MigrationCommand.HasFlag(MigrationCommand.Execute)))
-                    return new ValidationResult($"Additional arguments can only be specified when the command is '{nameof(MigrationCommand.Script)}' or '{nameof(MigrationCommand.Execute)}'.", new string[] { "args" });
+                if (_additionalArgs.Values.Count > 0 && !(Args.MigrationCommand.HasFlag(MigrationCommand.CodeGen) || Args.MigrationCommand.HasFlag(MigrationCommand.Script) || Args.MigrationCommand.HasFlag(MigrationCommand.Execute)))
+                    return new ValidationResult($"Additional arguments can only be specified when the command is '{nameof(MigrationCommand.CodeGen)}', '{nameof(MigrationCommand.Script)}' or '{nameof(MigrationCommand.Execute)}'.", new string[] { "args" });
 
-                if (Args.MigrationCommand.HasFlag(MigrationCommand.Script))
+                if (Args.MigrationCommand.HasFlag(MigrationCommand.CodeGen) || Args.MigrationCommand.HasFlag(MigrationCommand.Script))
                 {
                     for (int i = 0; i < _additionalArgs.Values.Count; i++)
                     {
-                        if (i == 0)
-                            Args.ScriptName = _additionalArgs.Values[i];
-                        else
-                        {
-                            Args.ScriptArguments ??= new Dictionary<string, string?>();
-                            Args.ScriptArguments.Add($"Param{i}", _additionalArgs.Values[i]);
-                        }
+                        Args.Parameters.Add($"Param{i}", _additionalArgs.Values[i]);
                     }
                 }
 

--- a/src/DbEx/DatabaseSchemaConfig.cs
+++ b/src/DbEx/DatabaseSchemaConfig.cs
@@ -106,7 +106,7 @@ namespace DbEx
         /// Opportunity to load additional `InformationSchema` related data that is specific to the database.
         /// </summary>
         /// <param name="database">The <see cref="IDatabase"/>.</param>
-        /// <param name="tables">The <see cref="DbTableSchema"/> list to load addtional data into.</param>
+        /// <param name="tables">The <see cref="DbTableSchema"/> list to load additional data into.</param>
         /// <param name="dataParserArgs">The <see cref="DataParserArgs"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         public virtual Task LoadAdditionalInformationSchema(IDatabase database, List<DbTableSchema> tables, DataParserArgs? dataParserArgs, CancellationToken cancellationToken) => Task.CompletedTask;
@@ -143,21 +143,21 @@ namespace DbEx
         public abstract string ToFormattedSqlStatementValue(DataParserArgs dataParserArgs, object? value);
 
         /// <summary>
-        /// Inidicates whether the <paramref name="dbType"/> is considered an integer.
+        /// Indicates whether the <paramref name="dbType"/> is considered an integer.
         /// </summary>
         /// <param name="dbType">The database type.</param>
         /// <returns><c>true</c> indicates it is; otherwise, <c>false</c>.</returns>
         public abstract bool IsDbTypeInteger(string? dbType);
 
         /// <summary>
-        /// Inidicates whether the <paramref name="dbType"/> is considered a decimal.
+        /// Indicates whether the <paramref name="dbType"/> is considered a decimal.
         /// </summary>
         /// <param name="dbType">The database type.</param>
         /// <returns><c>true</c> indicates it is; otherwise, <c>false</c>.</returns>
         public abstract bool IsDbTypeDecimal(string? dbType);
 
         /// <summary>
-        /// Inidicates whether the <paramref name="dbType"/> is considered a string.
+        /// Indicates whether the <paramref name="dbType"/> is considered a string.
         /// </summary>
         /// <param name="dbType">The database type.</param>
         /// <returns><c>true</c> indicates it is; otherwise, <c>false</c>.</returns>

--- a/src/DbEx/DbSchema/DbColumnSchema.cs
+++ b/src/DbEx/DbSchema/DbColumnSchema.cs
@@ -12,6 +12,7 @@ namespace DbEx.DbSchema
     public class DbColumnSchema
     {
         private string? _dotNetType;
+        private string? _dotNetName;
         private string? _sqlType;
 
         /// <summary>
@@ -128,21 +129,37 @@ namespace DbEx.DbSchema
         public string? ForeignRefDataCodeColumn { get; set; }
 
         /// <summary>
+        /// Indicates whether the column is a created audit column; i.e. name is <c>CreatedDate</c> or <c>CreatedBy</c>.
+        /// </summary>
+        public bool IsCreatedAudit { get; set; }
+
+        /// <summary>
+        /// Indicates whether the column is an updated audit column; i.e. name is <c>UpdatedDate</c> or <c>UpdatedBy</c>.
+        /// </summary>
+        public bool IsUpdatedAudit { get; set; }
+
+        /// <summary>
         /// Gets the corresponding .NET <see cref="System.Type"/> name.
         /// </summary>
-        public string DotNetType => _dotNetType ?? DbTable?.Config.ToDotNetTypeName(this) ?? throw new InvalidOperationException($"The {nameof(DbTable)} must be set before the {nameof(DotNetType)} property can be accessed.");
+        public string DotNetType => _dotNetType ??= DbTable?.Config.ToDotNetTypeName(this) ?? throw new InvalidOperationException($"The {nameof(DbTable)} must be set before the {nameof(DotNetType)} property can be accessed.");
+
+        /// <summary>
+        /// Gets the corresponding .NET name.
+        /// </summary>
+        public string DotNetName => _dotNetName ??= DbTableSchema.CreateDotNetName(Name);
 
         /// <summary>
         /// Gets the fully defined SQL type.
         /// </summary>
-        public string SqlType => _sqlType ?? DbTable?.Config.ToFormattedSqlType(this) ?? throw new InvalidOperationException($"The {nameof(DbTable)} must be set before the {nameof(SqlType)} property can be accessed.");
+        public string SqlType => _sqlType ??= DbTable?.Config.ToFormattedSqlType(this) ?? throw new InvalidOperationException($"The {nameof(DbTable)} must be set before the {nameof(SqlType)} property can be accessed.");
 
         /// <summary>
-        /// Prepares the schema by updating the calcuated properties: <see cref="DotNetType"/> and <see cref="SqlType"/>.
+        /// Prepares the schema by updating the calculated properties: <see cref="DotNetType"/>, <see cref="DotNetName"/> and <see cref="SqlType"/>.
         /// </summary>
         public void Prepare()
         {
             _dotNetType = DbTable.Config.ToDotNetTypeName(this);
+            _dotNetName = DbTableSchema.CreateDotNetName(Name);
             _sqlType = DbTable.Config.ToFormattedSqlType(this);
         }
 
@@ -179,7 +196,10 @@ namespace DbEx.DbSchema
             ForeignColumn = column.ForeignColumn;
             IsForeignRefData = column.IsForeignRefData;
             ForeignRefDataCodeColumn = column.ForeignRefDataCodeColumn;
+            IsCreatedAudit = column.IsCreatedAudit;
+            IsUpdatedAudit = column.IsUpdatedAudit;
             _dotNetType = column._dotNetType;
+            _dotNetName = column._dotNetName;
             _sqlType = column._sqlType;
         }
     }

--- a/src/DbEx/Migration/Data/DataRow.cs
+++ b/src/DbEx/Migration/Data/DataRow.cs
@@ -28,6 +28,21 @@ namespace DbEx.Migration.Data
         public List<DataColumn> Columns { get; } = new List<DataColumn>();
 
         /// <summary>
+        /// Gets the insert columns.
+        /// </summary>
+        public List<DataColumn> InsertColumns => Columns.Where(c => Table.InsertColumns.Any(x => x.Name == c.Name)).ToList();
+
+        /// <summary>
+        /// Gets the columns that are used for the merge insert.
+        /// </summary>
+        public List<DataColumn> MergeInsertColumns => Columns.Where(c => Table.MergeInsertColumns.Any(x => x.Name == c.Name)).ToList();
+
+        /// <summary>
+        /// Gets the columns that are used for the merge update.
+        /// </summary>
+        public List<DataColumn> MergeUpdateColumns => Columns.Where(c => Table.MergeUpdateColumns.Any(x => x.Name == c.Name)).ToList();
+
+        /// <summary>
         /// Adds a <see cref="DataColumn"/> to the row using the specified name and value.
         /// </summary>
         /// <param name="name">The column name.</param>

--- a/src/DbEx/Migration/Data/DataTable.cs
+++ b/src/DbEx/Migration/Data/DataTable.cs
@@ -110,16 +110,24 @@ namespace DbEx.Migration.Data
         public List<DbColumnSchema> Columns { get; } = new List<DbColumnSchema>();
 
         /// <summary>
+        /// Gets the insert columns.
+        /// </summary>
+        public List<DbColumnSchema> InsertColumns => Columns.Where(x => !x.IsUpdatedAudit).ToList();
+
+        /// <summary>
         /// Gets the merge match columns.
         /// </summary>
-        public List<DbColumnSchema> MergeMatchColumns => Columns.Where(x => 
-            !(x.Name == Args.CreatedDateColumnName || x.Name == Args.CreatedByColumnName || x.Name == Args.UpdatedDateColumnName || x.Name == Args.UpdatedDateColumnName)
-            && !(UseIdentifierGenerator && x.IsPrimaryKey)).ToList();
+        public List<DbColumnSchema> MergeMatchColumns => Columns.Where(x => !x.IsCreatedAudit && !x.IsUpdatedAudit && !(UseIdentifierGenerator && x.IsPrimaryKey)).ToList();
+
+        /// <summary>
+        /// Gets the merge insert columns.
+        /// </summary>
+        public List<DbColumnSchema> MergeInsertColumns => Columns.Where(x => !x.IsUpdatedAudit).ToList();
 
         /// <summary>
         /// Gets the merge update columns.
         /// </summary>
-        public List<DbColumnSchema> MergeUpdateColumns => Columns.Where(x => !(UseIdentifierGenerator && x.IsPrimaryKey)).ToList();
+        public List<DbColumnSchema> MergeUpdateColumns => Columns.Where(x => !x.IsCreatedAudit).ToList();
 
         /// <summary>
         /// Gets the primary key columns.

--- a/src/DbEx/Migration/DatabaseMigrationBase.cs
+++ b/src/DbEx/Migration/DatabaseMigrationBase.cs
@@ -169,7 +169,7 @@ namespace DbEx.Migration
 
             // Where only creating a new script, then quickly do it and get out of here!
             if (Args.MigrationCommand.HasFlag(MigrationCommand.Script))
-                return await CreateScriptAsync(Args.ScriptName, Args.ScriptArguments, cancellationToken).ConfigureAwait(false);
+                return await CreateScriptAsync(Args.Parameters["Param0"]!.ToString(), Args.CreateStringParameters(), cancellationToken).ConfigureAwait(false);
 
             // Where only executing SQL statement, then execute and get out of here!
             if (Args.MigrationCommand.HasFlag(MigrationCommand.Execute))
@@ -353,7 +353,7 @@ namespace DbEx.Migration
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogCritical(ex, "An error occured executing the script: {Message}", ex.Message);
+                    Logger.LogCritical(ex, "An error occurred executing the script: {Message}", ex.Message);
                     return false;
                 }
 

--- a/src/DbEx/Migration/MigrationArgsBase.cs
+++ b/src/DbEx/Migration/MigrationArgsBase.cs
@@ -53,7 +53,8 @@ namespace DbEx.Migration
         /// <summary>
         /// Gets the runtime parameters.
         /// </summary>
-        /// <remarks>The following parameter names are reserved for a specific internal purpose: <see cref="DatabaseNameParamName"/>, <see cref="JournalSchemaParamName"/> and <see cref="JournalTableParamName"/>.</remarks>
+        /// <remarks>The following parameter names are reserved for a specific internal purpose: <see cref="DatabaseNameParamName"/>, <see cref="JournalSchemaParamName"/> and <see cref="JournalTableParamName"/>.
+        /// <para><see cref="MigrationCommand.Script"/> and <see cref="MigrationCommand.CodeGen"/> can support additional command-line arguments; these are automatically added as '<c>ParamN</c>' where '<c>N</c>' is the zero-based index; e.g. '<c>Param0</c>'.</para></remarks>
         public Dictionary<string, object?> Parameters { get; } = new Dictionary<string, object?>();
 
         /// <summary>
@@ -75,16 +76,6 @@ namespace DbEx.Migration
         /// Gets or sets the <see cref="Data.DataParserArgs"/>.
         /// </summary>
         public DataParserArgs DataParserArgs { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MigrationCommand.Script"/> name.
-        /// </summary>
-        public string? ScriptName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MigrationCommand.Script"/> arguments.
-        /// </summary>
-        public IDictionary<string, string?>? ScriptArguments { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="MigrationCommand.Execute"/> statements.
@@ -173,16 +164,7 @@ namespace DbEx.Migration
             SchemaOrder.Clear();
             SchemaOrder.AddRange(args.SchemaOrder);
             DataParserArgs.CopyFrom(args.DataParserArgs);
-            ScriptName = args.ScriptName;
             DataResetFilterPredicate = args.DataResetFilterPredicate;
-
-            if (args.ScriptArguments == null)
-                ScriptArguments = null;
-            else
-            {
-                ScriptArguments = new Dictionary<string, string?>();
-                args.ScriptArguments.ForEach(x => ScriptArguments.Add(x.Key, x.Value));
-            }
 
             if (args.ExecuteStatements == null)
                 ExecuteStatements = null;
@@ -191,6 +173,23 @@ namespace DbEx.Migration
                 ExecuteStatements = new();
                 ExecuteStatements.AddRange(args.ExecuteStatements);
             }
+        }
+
+        /// <summary>
+        /// Creates a copy of the <see cref="Parameters"/> where all <see cref="KeyValuePair{TKey, TValue}.Value"/> are converted to a <see cref="string"/> or <c>null</c>.
+        /// </summary>
+        public IDictionary<string, string?> CreateStringParameters()
+        {
+            var dict = new Dictionary<string, string?>();
+            foreach (var item in Parameters)
+            {
+                if (item.Value == null)
+                    dict.Add(item.Key, null);
+                else
+                    dict.Add(item.Key, item.Value.ToString());
+            }
+
+            return dict;
         }
     }
 }

--- a/tests/DbEx.Test.Console/Migrations/003-create-test-gender-table.sql
+++ b/tests/DbEx.Test.Console/Migrations/003-create-test-gender-table.sql
@@ -1,5 +1,9 @@
 ﻿    CREATE TABLE [Test].[Gender] (
       [GenderId] INT NOT NULL IDENTITY(1, 1) PRIMARY KEY,
       [Code] NVARCHAR (50) NOT NULL UNIQUE,
-      [Text] VARCHAR (256) NOT NULL
+      [Text] VARCHAR (256) NOT NULL,
+      [CreatedBy] NVARCHAR (50) NULL,
+      [CreatedDate] DATETIME2 NULL,
+      [UpdatedBy] NVARCHAR (50) NULL,
+      [UpdatedDate] DATETIME2 NULL
     )

--- a/tests/DbEx.Test.Console/Migrations/006-create-test-person-table.sql
+++ b/tests/DbEx.Test.Console/Migrations/006-create-test-person-table.sql
@@ -1,6 +1,8 @@
 ﻿    CREATE TABLE [Test].[Person] (
       [PersonId] UNIQUEIDENTIFIER NOT NULL DEFAULT (NEWSEQUENTIALID()) PRIMARY KEY,
       [Name] NVARCHAR (200) NOT NULL,
-      [CreatedBy] NVARCHAR (200) NOT NULL,
-      [CreatedDate] DATETIME2 NOT NULL
+      [CreatedBy] NVARCHAR (200) NULL,
+      [CreatedDate] DATETIME2 NULL,
+      [UpdatedBy] NVARCHAR (200) NULL,
+      [UpdatedDate] DATETIME2 NULL
     )

--- a/tests/DbEx.Test.MySqlConsole/Migrations/003-create-test-gender-table.sql
+++ b/tests/DbEx.Test.MySqlConsole/Migrations/003-create-test-gender-table.sql
@@ -1,5 +1,9 @@
 ﻿    CREATE TABLE `gender` (
       `gender_id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
       `code` VARCHAR (50) NOT NULL UNIQUE,
-      `text` VARCHAR (256) NOT NULL
+      `text` VARCHAR (256) NOT NULL,
+      `created_by` VARCHAR (50) NULL,
+      `created_date` DATETIME NULL,
+      `updated_by` VARCHAR (50) NULL,
+      `updated_date` DATETIME NULL
     )

--- a/tests/DbEx.Test.MySqlConsole/Migrations/004-create-test-contact-table.sql
+++ b/tests/DbEx.Test.MySqlConsole/Migrations/004-create-test-contact-table.sql
@@ -6,5 +6,9 @@
       `contact_type_id` INT NOT NULL DEFAULT 1,
       `gender_id` INT NULL,
       `notes` TEXT NULL,
+      `created_by` VARCHAR (50) NULL,
+      `created_date` DATETIME NULL,
+      `updated_by` VARCHAR (50) NULL,
+      `updated_date` DATETIME NULL,
       CONSTRAINT `FK_Test_Contact_ContactType` FOREIGN KEY (`contact_type_id`) REFERENCES `contact_type` (`contact_type_id`)
     )

--- a/tests/DbEx.Test/DatabaseSchemaTest.cs
+++ b/tests/DbEx.Test/DatabaseSchemaTest.cs
@@ -43,6 +43,8 @@ namespace DbEx.Test
             Assert.IsTrue(tab.IsRefData);
             Assert.AreEqual(4, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
+            Assert.AreEqual("ContactType", tab.DotNetName);
+            Assert.AreEqual("ContactTypes", tab.PluralName);
 
             var col = tab.Columns[0];
             Assert.AreEqual("ContactTypeId", col.Name);
@@ -103,6 +105,8 @@ namespace DbEx.Test
             Assert.IsFalse(tab.IsRefData);
             Assert.AreEqual(8, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
+            Assert.AreEqual("Contact", tab.DotNetName);
+            Assert.AreEqual("Contacts", tab.PluralName);
 
             col = tab.Columns[0];
             Assert.AreEqual("ContactId", col.Name);
@@ -221,6 +225,8 @@ namespace DbEx.Test
             Assert.IsFalse(tab.IsRefData);
             Assert.AreEqual(4, tab.Columns.Count);
             Assert.AreEqual(2, tab.PrimaryKeyColumns.Count);
+            Assert.AreEqual("MultiPk", tab.DotNetName);
+            Assert.AreEqual("MultiPks", tab.PluralName);
 
             col = tab.Columns[0];
             Assert.AreEqual("Part1", col.Name);
@@ -315,8 +321,10 @@ namespace DbEx.Test
             Assert.AreEqual("[Test].[Person]", tab.QualifiedName);
             Assert.IsFalse(tab.IsAView);
             Assert.IsFalse(tab.IsRefData);
-            Assert.AreEqual(4, tab.Columns.Count);
+            Assert.AreEqual(6, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
+            Assert.AreEqual("Person", tab.DotNetName);
+            Assert.AreEqual("People", tab.PluralName);
 
             col = tab.Columns[0];
             Assert.AreEqual("PersonId", col.Name);
@@ -365,6 +373,8 @@ namespace DbEx.Test
             Assert.IsTrue(tab.IsRefData);
             Assert.AreEqual(4, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
+            Assert.AreEqual("ContactType", tab.DotNetName);
+            Assert.AreEqual("ContactTypes", tab.PluralName);
 
             var col = tab.Columns[0];
             Assert.AreEqual("contact_type_id", col.Name);
@@ -386,6 +396,7 @@ namespace DbEx.Test
             Assert.IsNull(col.ForeignTable);
             Assert.IsNull(col.ForeignColumn);
             Assert.IsNull(col.DefaultValue);
+            Assert.AreEqual("ContactTypeId", col.DotNetName);
 
             col = tab.Columns[1];
             Assert.AreEqual("code", col.Name);
@@ -407,6 +418,7 @@ namespace DbEx.Test
             Assert.IsNull(col.ForeignTable);
             Assert.IsNull(col.ForeignColumn);
             Assert.IsNull(col.DefaultValue);
+            Assert.AreEqual("Code", col.DotNetName);
 
             col = tab.Columns[2];
             Assert.AreEqual("text", col.Name);
@@ -423,8 +435,11 @@ namespace DbEx.Test
             Assert.AreEqual("`contact`", tab.QualifiedName);
             Assert.IsFalse(tab.IsAView);
             Assert.IsFalse(tab.IsRefData);
-            Assert.AreEqual(7, tab.Columns.Count);
+            Assert.AreEqual(11, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
+            Assert.AreEqual("Contact", tab.DotNetName);
+            Assert.AreEqual("Contacts", tab.PluralName);
+
 
             col = tab.Columns[0];
             Assert.AreEqual("contact_id", col.Name);
@@ -446,6 +461,7 @@ namespace DbEx.Test
             Assert.IsNull(col.ForeignTable);
             Assert.IsNull(col.ForeignColumn);
             Assert.IsNull(col.DefaultValue);
+            Assert.AreEqual("ContactId", col.DotNetName);
 
             col = tab.Columns[3];
             Assert.AreEqual("date_of_birth", col.Name);
@@ -467,6 +483,7 @@ namespace DbEx.Test
             Assert.IsNull(col.ForeignTable);
             Assert.IsNull(col.ForeignColumn);
             Assert.IsNull(col.DefaultValue);
+            Assert.AreEqual("DateOfBirth", col.DotNetName);
 
             col = tab.Columns[4];
             Assert.AreEqual("contact_type_id", col.Name);
@@ -489,6 +506,7 @@ namespace DbEx.Test
             Assert.AreEqual("contact_type_id", col.ForeignColumn);
             Assert.AreEqual("code", col.ForeignRefDataCodeColumn);
             Assert.AreEqual("1", col.DefaultValue);
+            Assert.AreEqual("ContactTypeId", col.DotNetName);
 
             col = tab.Columns[5];
             Assert.AreEqual("gender_id", col.Name);
@@ -540,6 +558,8 @@ namespace DbEx.Test
             Assert.IsFalse(tab.IsRefData);
             Assert.AreEqual(4, tab.Columns.Count);
             Assert.AreEqual(2, tab.PrimaryKeyColumns.Count);
+            Assert.AreEqual("MultiPk", tab.DotNetName);
+            Assert.AreEqual("MultiPks", tab.PluralName);
 
             col = tab.Columns[0];
             Assert.AreEqual("part1", col.Name);


### PR DESCRIPTION
- *Fixed:* The YAML-based `MigrationCommand.Data` logic previously set the `CreatedBy`, `CreatedDate`, `UpdatedBy` and `UpdatedDate` (or specified equivalent) regardless of whether the data was being inserted or merged (insert/update). This has been corrected such that the appropriate values are only set for the specific type of operation being performed; i.e. `Created*`-only or `Updated*`-only.
- *Fixed:* Enabled additional command-line arguments to be passed for `MigrationCommand.CodeGen` to enable inherited usage flexibility. Removed `MigrationArgsBase.ScriptName` and `MigrationArgsBase.ScriptArguments` and included within existing `MigrationArgsBase.Parameters` as singular dictionary of key/value pairs (simplification).