### PR TITLE
v2.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v2.3.10
+- *Fixed:* `DbTableSchema`, `DbColumnSchema` and `DataParserArgs` now correctly support the full range of by-convention properties (e.g. `RowVersion`, `TenantId` and `IsDeleted`). Both the `SqlServerSchemaConfig` and `MySqlSchemaConfig` updated to default names as appropriate.
+
 ## v2.3.9
 - *Fixed:* The YAML-based `MigrationCommand.Data` logic previously set the `CreatedBy`, `CreatedDate`, `UpdatedBy` and `UpdatedDate` (or specified equivalent) regardless of whether the data was being inserted or merged (insert/update). This has been corrected such that the appropriate values are only set for the specific type of operation being performed; i.e. `Created*`-only or `Updated*`-only.
 - *Fixed:* Enabled additional command-line arguments to be passed for `MigrationCommand.CodeGen` to enable inherited usage flexibility. Removed `MigrationArgsBase.ScriptName` and `MigrationArgsBase.ScriptArguments` and included within existing `MigrationArgsBase.Parameters` as singular dictionary of key/value pairs (simplification).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Represents the **NuGet** versions.
 
 ## v2.3.10
-- *Fixed:* `DbTableSchema`, `DbColumnSchema` and `DataParserArgs` now correctly support the full range of by-convention properties (e.g. `RowVersion`, `TenantId` and `IsDeleted`). Both the `SqlServerSchemaConfig` and `MySqlSchemaConfig` updated to default names as appropriate.
+- *Fixed:* `DbTableSchema`, `DbColumnSchema` and `DataParserArgs` now correctly support the full range of by-convention properties (e.g. `RowVersion`, `TenantId` and `IsDeleted`). Both the `SqlServerSchemaConfig` and `MySqlSchemaConfig` updated to default names as appropriate. Additional properties added to `Db*Schema` to support additional code-generation scenarios, etc.
 
 ## v2.3.9
 - *Fixed:* The YAML-based `MigrationCommand.Data` logic previously set the `CreatedBy`, `CreatedDate`, `UpdatedBy` and `UpdatedDate` (or specified equivalent) regardless of whether the data was being inserted or merged (insert/update). This has been corrected such that the appropriate values are only set for the specific type of operation being performed; i.e. `Created*`-only or `Updated*`-only.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.3.9</Version>
+    <Version>2.3.10</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/MySqlSchemaConfig.cs
+++ b/src/DbEx.MySql/MySqlSchemaConfig.cs
@@ -46,6 +46,18 @@ namespace DbEx.MySql
         public override string UpdatedByColumnName => "updated_by";
 
         /// <inheritdoc/>
+        /// <remarks>Value is '<c>tenant_id</c>'.</remarks>
+        public override string TenantIdColumnName => "tenant_id";
+
+        /// <inheritdoc/>
+        /// <remarks>Value is '<c>row_version</c>'.</remarks>
+        public override string RowVersionColumnName => "row_version";
+
+        /// <inheritdoc/>
+        /// <remarks>Value is '<c>is_deleted</c>'.</remarks>
+        public override string IsDeletedColumnName => "is_deleted";
+
+        /// <inheritdoc/>
         /// <remarks>Value is '<c>code</c>'.</remarks>
         public override string RefDataCodeColumnName => "code";
 
@@ -68,10 +80,16 @@ namespace DbEx.MySql
                 dataParserArgs.RefDataColumnDefaults.TryAdd("sort_order", i => i);
             }
 
+            dataParserArgs.IdColumnNameSuffix ??= IdColumnNameSuffix;
             dataParserArgs.CreatedByColumnName ??= CreatedByColumnName;
             dataParserArgs.CreatedDateColumnName ??= CreatedDateColumnName;
             dataParserArgs.UpdatedByColumnName ??= UpdatedByColumnName;
             dataParserArgs.UpdatedDateColumnName ??= UpdatedDateColumnName;
+            dataParserArgs.TenantIdColumnName ??= TenantIdColumnName;
+            dataParserArgs.RowVersionColumnName ??= RowVersionColumnName;
+            dataParserArgs.IsDeletedColumnName ??= IsDeletedColumnName;
+            dataParserArgs.RefDataCodeColumnName ??= RefDataCodeColumnName;
+            dataParserArgs.RefDataTextColumnName ??= RefDataTextColumnName;
         }
 
         /// <inheritdoc/>

--- a/src/DbEx.SqlServer/SqlServerSchemaConfig.cs
+++ b/src/DbEx.SqlServer/SqlServerSchemaConfig.cs
@@ -46,6 +46,18 @@ namespace DbEx.SqlServer
         public override string UpdatedByColumnName => "UpdatedBy";
 
         /// <inheritdoc/>
+        /// <remarks>Value is '<c>TenantId</c>'.</remarks>
+        public override string TenantIdColumnName => "TenantId";
+
+        /// <inheritdoc/>
+        /// <remarks>Value is '<c>RowVersion</c>'.</remarks>
+        public override string RowVersionColumnName => "RowVersion";
+
+        /// <inheritdoc/>
+        /// <remarks>Value is '<c>IsDeleted</c>'.</remarks>
+        public override string IsDeletedColumnName => "IsDeleted";
+
+        /// <inheritdoc/>
         /// <remarks>Value is '<c>Code</c>'.</remarks>
         public override string RefDataCodeColumnName => "Code";
 
@@ -68,10 +80,16 @@ namespace DbEx.SqlServer
                 dataParserArgs.RefDataColumnDefaults.TryAdd("SortOrder", i => i);
             }
 
+            dataParserArgs.IdColumnNameSuffix ??= IdColumnNameSuffix;
             dataParserArgs.CreatedByColumnName ??= CreatedByColumnName;
             dataParserArgs.CreatedDateColumnName ??= CreatedDateColumnName;
             dataParserArgs.UpdatedByColumnName ??= UpdatedByColumnName;
             dataParserArgs.UpdatedDateColumnName ??= UpdatedDateColumnName;
+            dataParserArgs.TenantIdColumnName ??= TenantIdColumnName;
+            dataParserArgs.RowVersionColumnName ??= RowVersionColumnName;
+            dataParserArgs.IsDeletedColumnName ??= IsDeletedColumnName;
+            dataParserArgs.RefDataCodeColumnName ??= RefDataCodeColumnName;
+            dataParserArgs.RefDataTextColumnName ??= RefDataTextColumnName;
         }
 
         /// <inheritdoc/>

--- a/src/DbEx/DatabaseSchemaConfig.cs
+++ b/src/DbEx/DatabaseSchemaConfig.cs
@@ -44,26 +44,32 @@ namespace DbEx
         /// <summary>
         /// Gets the name of the <see cref="IChangeLogAudit.CreatedDate"/> column (where it exists).
         /// </summary>
-        /// <remarks>Defaults to '<c>CreatedDate</c>'.</remarks>
         public abstract string CreatedDateColumnName { get; }
 
         /// <summary>
         /// Gets the name of the <see cref="IChangeLogAudit.CreatedBy"/> column (where it exists).
         /// </summary>
-        /// <remarks>Defaults to '<c>CreatedBy</c>'.</remarks>
         public abstract string CreatedByColumnName { get; }
 
         /// <summary>
         /// Gets the name of the <see cref="IChangeLogAudit.UpdatedDate"/> column (where it exists).
         /// </summary>
-        /// <remarks>Defaults to '<c>UpdatedDate</c>'.</remarks>
         public abstract string UpdatedDateColumnName { get; }
 
         /// <summary>
         /// Gets the name of the <see cref="IChangeLogAudit.UpdatedBy"/> column (where it exists).
         /// </summary>
-        /// <remarks>Defaults to '<c>UpdatedBy</c>'.</remarks>
         public abstract string UpdatedByColumnName { get; }
+
+        /// <summary>
+        /// Gets the name of the <see cref="ITenantId.TenantId"/> column (where it exists).
+        /// </summary>
+        public abstract string TenantIdColumnName { get; }
+
+        /// <summary>
+        /// Gets the name of the row-version (<see cref="IETag.ETag"/> equivalent) column (where it exists).
+        /// </summary>
+        public abstract string RowVersionColumnName { get; }
 
         /// <summary>
         /// Gets the default <see cref="IReferenceData.Code"/> column.
@@ -74,6 +80,11 @@ namespace DbEx
         /// Gets the default <see cref="IReferenceData.Text"/> column.
         /// </summary>
         public abstract string RefDataTextColumnName { get; }
+
+        /// <summary>
+        /// Gets the default <see cref="ILogicallyDeleted.IsDeleted"/> column.
+        /// </summary>
+        public abstract string IsDeletedColumnName { get; }
 
         /// <summary>
         /// Gets the default reference data predicate to determine <see cref="DbTableSchema.IsRefData"/>.

--- a/src/DbEx/DbSchema/DbColumnSchema.cs
+++ b/src/DbEx/DbSchema/DbColumnSchema.cs
@@ -13,6 +13,7 @@ namespace DbEx.DbSchema
     {
         private string? _dotNetType;
         private string? _dotNetName;
+        private string? _dotNetCleanedName;
         private string? _sqlType;
 
         /// <summary>
@@ -176,7 +177,12 @@ namespace DbEx.DbSchema
         /// <summary>
         /// Gets the corresponding .NET name.
         /// </summary>
-        public string DotNetName => _dotNetName ??= DbTableSchema.CreateDotNetName(Name, IsRefData || IsJsonContent);
+        public string DotNetName => _dotNetName ??= DbTableSchema.CreateDotNetName(Name);
+
+        /// <summary>
+        /// Gets the corresponding .NET name cleaned; by removing any known suffixes where <see cref="IsRefData"/> or <see cref="IsJsonContent"/> 
+        /// </summary>
+        public string DotNetCleanedName => _dotNetCleanedName ??= DbTableSchema.CreateDotNetName(Name, IsRefData || IsJsonContent);
 
         /// <summary>
         /// Gets the fully defined SQL type.
@@ -224,6 +230,7 @@ namespace DbEx.DbSchema
             IsIsDeleted = column.IsIsDeleted;
             _dotNetType = column._dotNetType;
             _dotNetName = column._dotNetName;
+            _dotNetCleanedName = column._dotNetCleanedName;
             _sqlType = column._sqlType;
         }
     }

--- a/src/DbEx/Migration/Data/DataParserArgs.cs
+++ b/src/DbEx/Migration/Data/DataParserArgs.cs
@@ -71,6 +71,24 @@ namespace DbEx.Migration.Data
         public string? UpdatedByColumnName { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of the <see cref="ITenantId.TenantId"/> column (where it exists).
+        /// </summary>
+        /// <remarks>Defaults to <see cref="DatabaseSchemaConfig.TenantIdColumnName"/> where not specified (i.e. <c>null</c>).</remarks>
+        public string? TenantIdColumnName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the row-version (<see cref="IETag.ETag"/> equivalent) column (where it exists).
+        /// </summary>
+        /// <remarks>Defaults to <see cref="DatabaseSchemaConfig.RowVersionColumnName"/> where not specified (i.e. <c>null</c>).</remarks>
+        public string? RowVersionColumnName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the <see cref="ILogicallyDeleted.IsDeleted"/> column (where it exists).
+        /// </summary>
+        /// <remarks>Defaults to <see cref="DatabaseSchemaConfig.IsDeletedColumnName"/> where not specified (i.e. <c>null</c>).</remarks>
+        public string? IsDeletedColumnName { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the <see cref="IReferenceData.Code"/> column.
         /// </summary>
         /// <remarks>Defaults to <see cref="DatabaseSchemaConfig.RefDataCodeColumnName"/> where not specified (i.e. <c>null</c>).</remarks>
@@ -169,10 +187,13 @@ namespace DbEx.Migration.Data
 
             UserName = args.UserName;
             DateTimeNow = args.DateTimeNow;
+            IdColumnNameSuffix = args.IdColumnNameSuffix;
             CreatedDateColumnName = args.CreatedDateColumnName;
             CreatedByColumnName = args.CreatedByColumnName;
             UpdatedDateColumnName = args.UpdatedDateColumnName;
             UpdatedByColumnName = args.UpdatedByColumnName;
+            RowVersionColumnName = args.RowVersionColumnName;
+            TenantIdColumnName = args.TenantIdColumnName;
             RefDataCodeColumnName = args.RefDataCodeColumnName;
             RefDataTextColumnName = args.RefDataTextColumnName;
             IdentifierGenerator = args.IdentifierGenerator;

--- a/tests/DbEx.Test/DatabaseSchemaTest.cs
+++ b/tests/DbEx.Test/DatabaseSchemaTest.cs
@@ -171,6 +171,9 @@ namespace DbEx.Test
             Assert.AreEqual("ContactTypeId", col.ForeignColumn);
             Assert.AreEqual("Code", col.ForeignRefDataCodeColumn);
             Assert.AreEqual("((1))", col.DefaultValue);
+            Assert.AreEqual("ContactTypeId", col.DotNetName);
+            Assert.AreEqual("ContactType", col.DotNetCleanedName);
+            Assert.IsTrue(col.IsRefData);
 
             col = tab.Columns[5];
             Assert.AreEqual("GenderId", col.Name);
@@ -399,6 +402,7 @@ namespace DbEx.Test
             Assert.IsNull(col.ForeignColumn);
             Assert.IsNull(col.DefaultValue);
             Assert.AreEqual("ContactTypeId", col.DotNetName);
+            Assert.AreEqual("ContactTypeId", col.DotNetCleanedName);
 
             col = tab.Columns[1];
             Assert.AreEqual("code", col.Name);

--- a/tests/DbEx.Test/DatabaseSchemaTest.cs
+++ b/tests/DbEx.Test/DatabaseSchemaTest.cs
@@ -192,9 +192,11 @@ namespace DbEx.Test
             Assert.AreEqual("Gender", col.ForeignTable);
             Assert.AreEqual("GenderId", col.ForeignColumn);
             Assert.IsNull(col.DefaultValue);
+            Assert.IsFalse(col.IsTenantId);
 
             col = tab.Columns[6];
             Assert.AreEqual("TenantId", col.Name);
+            Assert.IsTrue(col.IsTenantId);
 
             col = tab.Columns[7];
             Assert.AreEqual("Notes", col.Name);


### PR DESCRIPTION
- *Fixed:* `DbTableSchema`, `DbColumnSchema` and `DataParserArgs` now correctly support the full range of by-convention properties (e.g. `RowVersion`, `TenantId` and `IsDeleted`). Both the `SqlServerSchemaConfig` and `MySqlSchemaConfig` updated to default names as appropriate. Additional properties added to `Db*Schema` to support additional code-generation scenarios, etc.