### PR TITLE
v2.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Represents the **NuGet** versions.
 
+## v2.3.11
+- *Enhancement:* `DataParser.ParseJsonAsync` added to support JSON data file parsing in addition to the existing YAML. Files (embedded resources) can be mixed and matched as required.
+- *Enhancement:* `DataParser` supports specified schema of `*` to provide `DataConfig` that is applied to all tables in the YAML/JSON file.
+- *Enhancement:* `DataParser` supports hierarchical data (i.e parent/child) where the child row(s) are specified as a parent column value (must be an array). Will also attempt to update the child related column from the parent primary key where not specified to simplify specification.
+- *Fixed:* `DataParser` supports `bit` values of `0` and `1`, in addition to `false` and `true` respectively.
+- *Fixed:* `DataParser` constraint of table only being specified once in the YAML/JSON file has been removed; this is now supported. The underlying database insert or merge operations will be consolidated and executed in the sequence of initial specification.
+
 ## v2.3.10
 - *Fixed:* `DbTableSchema`, `DbColumnSchema` and `DataParserArgs` now correctly support the full range of by-convention properties (e.g. `RowVersion`, `TenantId` and `IsDeleted`). Both the `SqlServerSchemaConfig` and `MySqlSchemaConfig` updated to default names as appropriate. Additional properties added to `Db*Schema` to support additional code-generation scenarios, etc.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.3.10</Version>
+    <Version>2.3.11</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ The `Schema` folder is used to encourage the usage of database schemas. Therefor
 
 ### Data
 
-Data can be defined using [YAML](https://en.wikipedia.org/wiki/YAML) to enable simplified configuration that will be used to generate the required SQL statements to apply to the database.
+Data can be defined using [YAML](https://en.wikipedia.org/wiki/YAML) or JSON to enable simplified configuration that will be used to generate the required SQL statements to apply to the database.
 
 The data specified follows a basic indenting/levelling rule to enable:
 1. **Schema** - specifies Schema name.
 2. **Table** - specifies the Table name within the Schema; this will be validated to ensure it exists within the database as the underlying table schema (columns) will be inferred. The underyling rows will be [inserted](https://docs.microsoft.com/en-us/sql/t-sql/statements/insert-transact-sql) by default; or alternatively by prefixing with a `$` character a [merge](https://docs.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql) operation will be performed instead.
 3. **Rows** - each row specifies the column name and the corresponding values (except for reference data described below). The tooling will parse each column value according to the underying SQL type.
 
-Finally, SQL script files can also be provided in addition to YAML where explicit SQL is to be executed.
+Additionally, SQL script files can also be provided in addition to YAML and JSON where explicit SQL is to be executed.
 
 <br/>
 
@@ -139,7 +139,7 @@ Alternatively, a *Reference Data* reference could be the code itself, typically 
 
 <br/>
 
-#### YAML configuration
+#### YAML/JSON configuration
 
 Example YAML configuration for *merging* reference data is as follows.
 
@@ -175,7 +175,7 @@ Demo:
     - { FirstName: Wendy, LastName: Jones, Gender: F, Birthday: 1985-03-18 }
 ```
 
-Finally, runtime values can be used within the YAML using the value lookup notation; this notation is `^(Key)`. This will either reference the [`DataParserArgs`](./src/DbEx/Migration/Data/DataParserArgs.cs) `Parameters` property using the specified key. There are two special parameters, being `UserName` and `DateTimeNow`, that reference the same named `DataParserArgs` properties. Where not found the extended notation `^(Namespace.Type.Property.Method().etc, AssemblyName)` is used. Where the `AssemblyName` is not specified then the default `mscorlib` is assumed. The `System` root namespace is optional, i.e. it will be attempted by default. The initial property or method for a `Type` must be `static`, in that the `Type` will not be instantiated. Example as follows. These parameters (`Name=Value` pairs) can also be command-line specified.
+Runtime values can be used within the YAML using the value lookup notation; this notation is `^(Key)`. This will either reference the [`DataParserArgs`](./src/DbEx/Migration/Data/DataParserArgs.cs) `Parameters` property using the specified key. There are two special parameters, being `UserName` and `DateTimeNow`, that reference the same named `DataParserArgs` properties. Where not found the extended notation `^(Namespace.Type.Property.Method().etc, AssemblyName)` is used. Where the `AssemblyName` is not specified then the default `mscorlib` is assumed. The `System` root namespace is optional, i.e. it will be attempted by default. The initial property or method for a `Type` must be `static`, in that the `Type` will not be instantiated. Example as follows. These parameters (`Name=Value` pairs) can also be command-line specified.
 
 ``` yaml
 Demo:
@@ -183,6 +183,9 @@ Demo:
     - { FirstName: Wendy, Username: ^(System.Security.Principal.WindowsIdentity.GetCurrent().Name,System.Security.Principal.Windows), Birthday: ^(DateTimeNow) }
     - { FirstName: Wendy, Username: ^(Beef.ExecutionContext.EnvironmentUsername,Beef.Core), Birthday: ^(DateTime.UtcNow) }
 ```
+
+Advanced capabilities, such as nested YAML/JSON can be specified to represent hierarchical relationships (see `contact->addresses` within test [`data.yaml`](./tests/DbEx.Test.Console/Data/Data.yaml) and related [`TableNameMappings`](./tests/DbEx.Test.Console/Program.cs) to map to the correct underlying database table). [`DataConfig`](./src/Dbex/Migration/Data/DataConfig.cs) can also be specified using the `*` schema to control the behaviour within the context of a YAML/JSON file as demonstrated by the test [`ContactType.json`](./tests/DbEx.Test.Console/Data/ContactType.json).
+
 
 <br/>
 

--- a/src/DbEx.MySql/MySqlSchemaConfig.cs
+++ b/src/DbEx.MySql/MySqlSchemaConfig.cs
@@ -214,7 +214,7 @@ namespace DbEx.MySql
         }
 
         /// <inheritdoc/>
-        public override string ToFormattedSqlStatementValue(DataParserArgs dataParserArgs, object? value) => value switch
+        public override string ToFormattedSqlStatementValue(DbColumnSchema dbColumnSchema, DataParserArgs dataParserArgs, object? value) => value switch
         {
             null => "NULL",
             string str => $"'{str.Replace("'", "''", StringComparison.Ordinal)}'",

--- a/src/DbEx.MySql/Resources/DatabaseData_sql.hbs
+++ b/src/DbEx.MySql/Resources/DatabaseData_sql.hbs
@@ -1,4 +1,8 @@
 ﻿{{! Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx }}
+{{#if PreSql}}
+{{PreSql}}
+
+{{/if}}
 {{#if IsMerge}}
   {{#each Rows}}
 INSERT INTO `{{Table.Name}}` ({{#each MergeInsertColumns}}`{{Name}}`{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each MergeInsertColumns}}{{#if UseForeignKeyQueryForId}}(SELECT `{{DbColumn.ForeignColumn}}` FROM `{{DbColumn.ForeignTable}}` WHERE `{{DbColumn.ForeignRefDataCodeColumn}}` = {{{SqlValue}}} LIMIT 1){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}}) ON DUPLICATE KEY UPDATE {{#each MergeUpdateColumns}}`{{Name}}` = {{{SqlValue}}}{{#unless @last}}, {{/unless}}{{/each}};
@@ -9,4 +13,8 @@ SELECT {{Rows.Count}}; -- Total rows upserted
 INSERT INTO `{{Table.Name}}` ({{#each InsertColumns}}`{{Name}}`{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each InsertColumns}}{{#if UseForeignKeyQueryForId}}(SELECT `{{DbColumn.ForeignColumn}}` FROM `{{DbColumn.ForeignTable}}` WHERE `{{DbColumn.ForeignRefDataCodeColumn}}` = {{{SqlValue}}} LIMIT 1){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}});
   {{/each}}
 SELECT {{Rows.Count}}; -- Total rows inserted
+{{/if}}
+{{#if PostSql}}
+
+{{PostSql}}
 {{/if}}

--- a/src/DbEx.SqlServer/Resources/DatabaseData_sql.hbs
+++ b/src/DbEx.SqlServer/Resources/DatabaseData_sql.hbs
@@ -1,4 +1,8 @@
 ﻿{{! Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx }}
+{{#if PreSql}}
+{{PreSql}}
+
+{{/if}}
 {{#if IsMerge}}
 CREATE TABLE #temp (
   {{#each Columns}}
@@ -28,4 +32,8 @@ DROP TABLE #temp
 INSERT INTO [{{Table.Schema}}].[{{Table.Name}}] ({{#each InsertColumns}}[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}}) VALUES ({{#each InsertColumns}}{{#if UseForeignKeyQueryForId}}(SELECT TOP 1 [{{DbColumn.ForeignColumn}}] FROM [{{DbColumn.ForeignSchema}}].[{{DbColumn.ForeignTable}}] WHERE [{{DbColumn.ForeignRefDataCodeColumn}}] = {{{SqlValue}}}){{else}}{{{SqlValue}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}})
   {{/each}}
 SELECT {{Rows.Count}} -- Total rows inserted
+{{/if}}
+{{#if PostSql}}
+
+{{PostSql}}
 {{/if}}

--- a/src/DbEx.SqlServer/SqlServerSchemaConfig.cs
+++ b/src/DbEx.SqlServer/SqlServerSchemaConfig.cs
@@ -233,7 +233,7 @@ namespace DbEx.SqlServer
         }
 
         /// <inheritdoc/>
-        public override string ToFormattedSqlStatementValue(DataParserArgs dataParserArgs, object? value) => value switch
+        public override string ToFormattedSqlStatementValue(DbColumnSchema dbColumnSchema, DataParserArgs dataParserArgs, object? value) => value switch
         {
             null => "NULL",
             string str => $"N'{str.Replace("'", "''", StringComparison.Ordinal)}'",

--- a/src/DbEx/DatabaseSchemaConfig.cs
+++ b/src/DbEx/DatabaseSchemaConfig.cs
@@ -148,10 +148,11 @@ namespace DbEx
         /// <summary>
         /// Gets the formatted SQL statement representation of the <paramref name="value"/>.
         /// </summary>
+        /// <param name="dbColumnSchema">The <see cref="DbColumnSchema"/>.</param>
         /// <param name="dataParserArgs">The <see cref="DataParserArgs"/>.</param>
         /// <param name="value">The value.</param>
         /// <returns>The formatted SQL statement representation.</returns>
-        public abstract string ToFormattedSqlStatementValue(DataParserArgs dataParserArgs, object? value);
+        public abstract string ToFormattedSqlStatementValue(DbColumnSchema dbColumnSchema, DataParserArgs dataParserArgs, object? value);
 
         /// <summary>
         /// Indicates whether the <paramref name="dbType"/> is considered an integer.

--- a/src/DbEx/DbSchema/DbTableSchema.cs
+++ b/src/DbEx/DbSchema/DbTableSchema.cs
@@ -67,7 +67,7 @@ namespace DbEx.DbSchema
         }
 
         /// <summary>
-        /// Create a plural from the name.
+        /// Create a plural from the singular name.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <returns>The pluralized name.</returns>
@@ -78,6 +78,21 @@ namespace DbEx.DbSchema
 
             var words = Regex.Split(name, WordSplitPattern).Where(x => !string.IsNullOrEmpty(x)).ToList();
             words[^1] = StringConverter.ToPlural(words[^1]);
+            return string.Join(string.Empty, words);
+        }
+
+        /// <summary>
+        /// Create a singular from the pluralized name.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <returns>The singular name.</returns>
+        public static string CreateSingularName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentNullException(nameof(name));
+
+            var words = Regex.Split(name, WordSplitPattern).Where(x => !string.IsNullOrEmpty(x)).ToList();
+            words[^1] = StringConverter.ToSingle(words[^1]);
             return string.Join(string.Empty, words);
         }
 

--- a/src/DbEx/Migration/Data/DataColumn.cs
+++ b/src/DbEx/Migration/Data/DataColumn.cs
@@ -19,6 +19,10 @@ namespace DbEx.Migration.Data
         {
             Table = table ?? throw new ArgumentNullException(nameof(table));
             Name = name ?? throw new ArgumentNullException(nameof(name));
+
+            // Map the column name where specified.
+            if (table.ColumnNameMappings is not null && table.ColumnNameMappings.TryGetValue(name, out var mappedName))
+                Name = mappedName;
         }
 
         /// <summary>
@@ -50,6 +54,6 @@ namespace DbEx.Migration.Data
         /// Gets the value formatted for use in a SQL statement.
         /// </summary>
         /// <returns>The value formatted for use in a SQL statement.</returns>
-        public string SqlValue => Table.DbTable.Config.ToFormattedSqlStatementValue(Table.Args, Value);
+        public string SqlValue => Table.DbTable.Config.ToFormattedSqlStatementValue(DbColumn ?? throw new InvalidOperationException("The DbColumn property must not be null."), Table.Args, Value);
     }
 }

--- a/src/DbEx/Migration/Data/DataConfig.cs
+++ b/src/DbEx/Migration/Data/DataConfig.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+namespace DbEx.Migration.Data
+{
+    /// <summary>
+    /// Respresents the data configuration.
+    /// </summary>
+    public class DataConfig
+    {
+        /// <summary>
+        /// Gets or sets the pre-condition SQL.
+        /// </summary>
+        public string? PreConditionSql { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pre-SQL.
+        /// </summary>
+        public string? PreSql { get; set; }
+
+        /// <summary>
+        /// Gets or sets the post-SQL.
+        /// </summary>
+        public string? PostSql { get; set; }
+    }
+}

--- a/src/DbEx/Migration/Data/DataParser.cs
+++ b/src/DbEx/Migration/Data/DataParser.cs
@@ -2,6 +2,7 @@
 
 using DbEx.DbSchema;
 using HandlebarsDotNet;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -84,6 +85,42 @@ namespace DbEx.Migration.Data
         }
 
         /// <summary>
+        /// Reads and parses the database using the specified JSON <see cref="string"/>.
+        /// </summary>
+        /// <param name="json">The JSON <see cref="string"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The resulting <see cref="DataTable"/> list.</returns>
+        public Task<List<DataTable>> ParseJsonAsync(string json, CancellationToken cancellationToken = default)
+        {
+            using var sr = new StringReader(json);
+            return ParseJsonAsync(sr, cancellationToken);
+        }
+
+        /// <summary>
+        /// Reads and parses the database using the specified JSON <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="s">The JSON <see cref="Stream"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The resulting <see cref="DataTable"/> list.</returns>
+        public Task<List<DataTable>> ParseJsonAsync(Stream s, CancellationToken cancellationToken = default)
+        {
+            using var sr = new StreamReader(s);
+            return ParseJsonAsync(sr, cancellationToken);
+        }
+
+        /// <summary>
+        /// Reads and parses the database using the specified JSON <see cref="TextReader"/>.
+        /// </summary>
+        /// <param name="tr">The JSON <see cref="TextReader"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The resulting <see cref="DataTable"/> list.</returns>
+        public Task<List<DataTable>> ParseJsonAsync(TextReader tr, CancellationToken cancellationToken = default)
+        {
+            using var jr = new JsonTextReader(tr);
+            return ParseJsonAsync(JObject.Load(jr), cancellationToken);
+        }
+
+        /// <summary>
         /// Reads and parses the database using the specified <see cref="JObject"/>.
         /// </summary>
         private async Task<List<DataTable>> ParseJsonAsync(JObject json, CancellationToken cancellationToken)
@@ -94,66 +131,97 @@ namespace DbEx.Migration.Data
 
             // Parse table/row/column data.
             var tables = new List<DataTable>();
+            DataConfig? dataConfig = null;
 
             // Loop through all the schemas.
             foreach (var js in json.Children<JProperty>())
             {
+                // Check for data configuration as identified by the * schema - which is a special key notation.
+                if (js.Name == "*")
+                {
+                    dataConfig = js.Children<JObject>().FirstOrDefault()?.ToObject<DataConfig?>();
+                    continue;
+                }
+
                 // Loop through the collection of tables.
                 foreach (var jto in GetChildObjects(js))
                 {
                     foreach (var jt in jto.Children<JProperty>())
                     {
-                        var sdt = new DataTable(this, DatabaseSchemaConfig.SupportsSchema ? js.Name : string.Empty, jt.Name);
-                        if (tables.Any(t => t.Schema == sdt.Schema && t.Name == sdt.Name))
-                            throw new DataParserException($"Table '{sdt.Schema}.{sdt.Name}' has been specified more than once.");
-
-                        // Loop through the collection of rows.
-                        foreach (var jro in GetChildObjects(jt))
-                        {
-                            var row = new DataRow(sdt);
-
-                            foreach (var jr in jro.Children<JProperty>())
-                            {
-                                if (jr.Value.Type == JTokenType.Object)
-                                {
-                                    foreach (var jc in jro.Children<JProperty>())
-                                    {
-                                        var col = sdt.IsRefData ? (Args.RefDataCodeColumnName ?? DatabaseSchemaConfig.RefDataCodeColumnName) : sdt.DbTable.Columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).SingleOrDefault();
-                                        if (!string.IsNullOrEmpty(col))
-                                        {
-                                            row.AddColumn(col, GetColumnValue(jc.Name));
-                                            foreach (var jcv in jc.Values().Where(j => j.Type == JTokenType.Property).Cast<JProperty>())
-                                            {
-                                                row.AddColumn(jcv.Name, GetColumnValue(jcv.Value));
-                                            }
-                                        }
-                                    }
-                                }
-                                else
-                                {
-                                    if (sdt.IsRefData && jro.Children().Count() == 1)
-                                    {
-                                        row.AddColumn(Args.RefDataCodeColumnName ?? DatabaseSchemaConfig.RefDataCodeColumnName, GetColumnValue(jr.Name));
-                                        row.AddColumn(Args.RefDataTextColumnName ?? DatabaseSchemaConfig.RefDataTextColumnName, GetColumnValue(jr.Value));
-                                    }
-                                    else
-                                        row.AddColumn(jr.Name, GetColumnValue(jr.Value));
-                                }
-                            }
-
-                            sdt.AddRow(row);
-                        }
-
-                        if (sdt.Columns.Count > 0)
-                        {
-                            await sdt.PrepareAsync(cancellationToken).ConfigureAwait(false);
-                            tables.Add(sdt);
-                        }
+                        await ParseTableJsonAsync(tables, null, js.Name, jt, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
 
+            // Applies the data configuration where specified.
+            if (dataConfig is not null)
+            {
+                foreach (var dt in tables)
+                {
+                    dt.ApplyConfig(dataConfig);
+                }
+            }
+
             return tables;
+        }
+
+        /// <summary>
+        /// Reads and parses the table data.
+        /// </summary>
+        private async Task ParseTableJsonAsync(List<DataTable> tables, DataRow? parent, string schema, JProperty jt, CancellationToken cancellationToken)
+        {
+            // Get existing or create new table.
+            var sdt = new DataTable(this, DatabaseSchemaConfig.SupportsSchema ? schema : string.Empty, jt.Name);
+            var prev = tables.SingleOrDefault(x => x.Schema == sdt.Schema && x.Name == sdt.Name);
+            if (prev is null)
+                tables.Add(sdt);
+            else
+                sdt = prev;
+
+            // Loop through the collection of rows.
+            foreach (var jro in GetChildObjects(jt))
+            {
+                var row = new DataRow(sdt);
+
+                foreach (var jr in jro.Children<JProperty>())
+                {
+                    if (jr.Value.Type == JTokenType.Object)
+                    {
+                        throw new DataParserException($"Table '{sdt.Schema}.{sdt.Name}' has unsupported '{jr.Name}' column value; must not be an object: {jr.Value}.");
+                    }
+                    else if (jr.Value.Type == JTokenType.Array)
+                    {
+                        // Try parsing as a further described nested table configuration; i.e. representing a relationship.
+                        await ParseTableJsonAsync(tables, row, sdt.Schema, jr, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        if (sdt.IsRefData && jro.Children().Count() == 1)
+                        {
+                            row.AddColumn(Args.RefDataCodeColumnName ?? DatabaseSchemaConfig.RefDataCodeColumnName, GetColumnValue(jr.Name));
+                            row.AddColumn(Args.RefDataTextColumnName ?? DatabaseSchemaConfig.RefDataTextColumnName, GetColumnValue(jr.Value));
+                        }
+                        else
+                            row.AddColumn(jr.Name, GetColumnValue(jr.Value));
+                    }
+                }
+
+                // Where specified within a hierarchy attempt to be fancy and auto-update from the parent's primary key where same name.
+                if (parent is not null)
+                {
+                    foreach (var pktc in parent.Table.DbTable.PrimaryKeyColumns)
+                    {
+                        var pkc = parent.Columns.SingleOrDefault(x => x.Name == pktc.Name);
+                        if (pkc is not null && row.Table.DbTable.Columns.Any(x => x.Name == pktc.Name) && row.Columns.SingleOrDefault(x => x.Name == pktc.Name) is null)
+                            row.AddColumn(pkc.Name, pkc.Value);
+                    }
+                }
+
+                sdt.AddRow(row);
+            }
+
+            if (sdt.Columns.Count > 0)
+                await sdt.PrepareAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -180,7 +248,7 @@ namespace DbEx.Migration.Data
                 JTokenType.Date => j.Value<DateTime>(),
                 JTokenType.Float => j.Value<float>(),
                 JTokenType.Guid => j.Value<Guid>(),
-                JTokenType.Integer => j.Value<int>(),
+                JTokenType.Integer => j.Value<long>(),
                 JTokenType.TimeSpan => j.Value<TimeSpan>(),
                 JTokenType.Uri => j.Value<string>(),
                 JTokenType.String => GetRuntimeParameterValue(j.Value<string>()),

--- a/src/DbEx/Migration/Data/DataParserArgs.cs
+++ b/src/DbEx/Migration/Data/DataParserArgs.cs
@@ -177,6 +177,11 @@ namespace DbEx.Migration.Data
         public Func<IEnumerable<DbTableSchema>, CancellationToken, Task<IEnumerable<DbTableSchema>>>? DbSchemaUpdaterAsync { get; set; }
 
         /// <summary>
+        /// Gets the <see cref="DataParserTableNameMappings"/>.
+        /// </summary>
+        public DataParserTableNameMappings TableNameMappings { get; } = new DataParserTableNameMappings();
+
+        /// <summary>
         /// Copy and replace from <paramref name="args"/>.
         /// </summary>
         /// <param name="args">The <see cref="DataParserArgs"/> to copy from.</param>
@@ -205,6 +210,8 @@ namespace DbEx.Migration.Data
             args.ColumnDefaults.ForEach(ColumnDefaults.Add);
             Parameters.Clear();
             args.Parameters.ForEach(x => Parameters.Add(x.Key, x.Value));
+            TableNameMappings.Clear();
+            args.TableNameMappings.ForEach(x => TableNameMappings.Add(x.Key.ParsedSchema, x.Key.ParsedTable, x.Value.Schema, x.Value.Table, x.Value.ColumnMappings));
         }
     }
 }

--- a/src/DbEx/Migration/Data/DataParserTableNameMappings.cs
+++ b/src/DbEx/Migration/Data/DataParserTableNameMappings.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DbEx.Migration.Data
+{
+    /// <summary>
+    /// Provides <see cref="DataParser"/> schema, table and column name mappings.
+    /// </summary>
+    public class DataParserTableNameMappings : IEnumerable<KeyValuePair<(string ParsedSchema, string ParsedTable), (string Schema, string Table, Dictionary<string, string>? ColumnMappings)>>
+    {
+        private readonly Dictionary<(string, string), (string, string, Dictionary<string, string>?)> _dict = new();
+
+        /// <summary>
+        /// Adds a schema, table and column(s) mapping.
+        /// </summary>
+        /// <param name="parsedSchema">The parsed schema name.</param>
+        /// <param name="parsedTable">The parsed table name.</param>
+        /// <param name="schema">The mapped database schema name.</param>
+        /// <param name="table">The mapped database table name.</param>
+        /// <param name="columnMappings">The optional parsed and mapped database column names.</param>
+        /// <returns>The <see cref="DataParserTableNameMappings"/> instance to support fluent-style method-chaining.</returns>
+        public DataParserTableNameMappings Add(string? parsedSchema, string parsedTable, string? schema, string table, Dictionary<string, string>? columnMappings = null)
+        {
+            _dict.Add((EmptyWhereNull(parsedSchema), parsedTable), (EmptyWhereNull(schema), table, columnMappings));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds column(s) mappings.
+        /// </summary>
+        /// <param name="schema">The mapped database schema name.</param>
+        /// <param name="table">The mapped database table name.</param>
+        /// <param name="columnMappings">The parsed and mapped database column names.</param>
+        /// <returns>The <see cref="DataParserTableNameMappings"/> instance to support fluent-style method-chaining.</returns>
+        public DataParserTableNameMappings Add(string? schema, string table, Dictionary<string, string> columnMappings)
+        {
+            _dict.Add((EmptyWhereNull(schema), table), (EmptyWhereNull(schema), table, columnMappings ?? throw new ArgumentNullException(nameof(columnMappings))));
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the table mapping.
+        /// </summary>
+        /// <param name="parsedSchema">The parsed schema name.</param>
+        /// <param name="parsedTable">The parsed table name.</param>
+        /// <returns>The mapped database schema, table and column name mappings.</returns>
+        public (string Schema, string Table, IDictionary<string, string>? ColumnMappings) Get(string? parsedSchema, string parsedTable)
+            => _dict.TryGetValue((EmptyWhereNull(parsedSchema), parsedTable), out var value) ? value : new (EmptyWhereNull(parsedSchema), parsedTable, null);
+
+        /// <summary>
+        /// Empties the value where null.
+        /// </summary>
+        private static string EmptyWhereNull(string? value) => value ?? string.Empty;
+
+        /// <summary>
+        /// Removes all mappings.
+        /// </summary>
+        public void Clear() => _dict.Clear();
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<(string ParsedSchema, string ParsedTable), (string Schema, string Table, Dictionary<string, string>? ColumnMappings)>> IEnumerable<KeyValuePair<(string ParsedSchema, string ParsedTable), (string Schema, string Table, Dictionary<string, string>? ColumnMappings)>>.GetEnumerator()
+            => _dict.GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => _dict.GetEnumerator();
+    }
+}

--- a/src/DbEx/Migration/Data/DataRow.cs
+++ b/src/DbEx/Migration/Data/DataRow.cs
@@ -89,19 +89,21 @@ namespace DbEx.Migration.Data
                 switch (col.DotNetType)
                 {
                     case "string": column.Value = str; break;
-                    case "decimal": column.Value = decimal.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
-                    case "DateTime": column.Value = DateTime.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
-                    case "bool": column.Value = bool.Parse(str); break;
-                    case "DateTimeOffset": column.Value = DateTimeOffset.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
-                    case "double": column.Value = double.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
-                    case "short": column.Value = short.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
-                    case "byte": column.Value = byte.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
-                    case "float": column.Value = float.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
-                    case "TimeSpan": column.Value = TimeSpan.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
+                    case "decimal": column.Value = string.IsNullOrEmpty(str) ? 0m : decimal.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
+                    case "DateTime": column.Value = string.IsNullOrEmpty(str) ? DateTime.MinValue : DateTime.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
+                    case "bool": column.Value = str switch { "1" or "Y" => true, "0" or "N" or "" => false, _ => bool.Parse(str) }; break;
+                    case "DateTimeOffset": column.Value = string.IsNullOrEmpty(str) ? DateTimeOffset.MinValue : DateTimeOffset.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
+                    case "double": column.Value = string.IsNullOrEmpty(str) ? 0d : double.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
+                    case "short": column.Value = string.IsNullOrEmpty(str) ? (short)0 : short.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
+                    case "byte": column.Value = string.IsNullOrEmpty(str) ? byte.MinValue : byte.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
+                    case "float": column.Value = string.IsNullOrEmpty(str) ? 0f : float.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
+                    case "TimeSpan": column.Value = string.IsNullOrEmpty(str) ? TimeSpan.Zero : TimeSpan.Parse(str, System.Globalization.CultureInfo.InvariantCulture); break;
 
                     case "int":
                         if (int.TryParse(str, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out int i))
                             column.Value = i;
+                        else if (string.IsNullOrEmpty(str))
+                            column.Value = 0;
                         else if (col.IsForeignRefData)
                         {
                             column.Value = str;
@@ -115,6 +117,8 @@ namespace DbEx.Migration.Data
                     case "long":
                         if (long.TryParse(str, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out long l))
                             column.Value = l;
+                        else if (string.IsNullOrEmpty(str))
+                            column.Value = 0L;
                         else if (col.IsForeignRefData)
                         {
                             column.Value = str;
@@ -128,6 +132,8 @@ namespace DbEx.Migration.Data
                     case "Guid":
                         if (int.TryParse(str, out int a))
                             column.Value = DataValueConverter.IntToGuid(a);
+                        else if (string.IsNullOrEmpty(str))
+                            column.Value = Guid.Empty;
                         else
                         {
                             if (Guid.TryParse(str, out Guid g))

--- a/tests/DbEx.Test.Console/Data/ContactType.json
+++ b/tests/DbEx.Test.Console/Data/ContactType.json
@@ -1,0 +1,25 @@
+{
+  "*": {
+    "preConditionSql": "SELECT CASE WHEN EXISTS (SELECT * FROM [{{schema}}].[{{table}}]) THEN 0 ELSE 1 END;",
+    "preSql": "SET IDENTITY_INSERT [{{schema}}].[{{table}}] ON;",
+    "postSql": "SET IDENTITY_INSERT [{{schema}}].[{{table}}] OFF; DBCC CHECKIDENT ('{{schema}}.{{table}}', RESEED)"
+  },
+  "XTest": [
+    {
+      "XContactType": [
+        {
+          "ContactTypeId": 1,
+          "Code": "E",
+          "Text": "External",
+          "IsFlag": 1,
+          "XNumber": 4245422915
+        },
+        {
+          "ContactTypeId": 2,
+          "Code": "I",
+          "Text": "Internal"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/DbEx.Test.Console/Data/Data.yaml
+++ b/tests/DbEx.Test.Console/Data/Data.yaml
@@ -1,14 +1,13 @@
 ﻿Test:
-- $ContactType:
-  - E: External
-  - I: Internal
 - $Gender:
   - F: Female
   - M: Male
   - O: Other
 - Contact:
-  - { ContactId: 1, ContactType: E, Gender: M, Name: Bob, DateOfBirth: 2001-10-22 }
-  - { ContactId: 2, ContactType: I, Name: Jane, Phone: 1234 }
+  - { ContactId: 1, ContactType: E, Gender: M, Name: Bob, DateOfBirth: 2001-10-22, Addresses: [ { ContactAddressId: 10, Street: "1 Main Street" } ] }
+  - { ContactId: 2, ContactType: I, Name: Jane, Phone: 1234, Addresses: [ { ContactAddressId: 20, ContactId: 2, Street: "1 Main Street" } ] }
 - ^Person:
   - { PersonId: 88, Name: '^(DbEx.Test.Console.RuntimeValues.Name, DbEx.Test.Console)' }
   - { Name: '^(DefaultName)' }
+- $Gender:
+  - X: Not specified

--- a/tests/DbEx.Test.Console/DbEx.Test.Console.csproj
+++ b/tests/DbEx.Test.Console/DbEx.Test.Console.csproj
@@ -12,6 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Data\ContactType.json" />
+    <None Remove="Migrations\004a-create-test-contact-address-table.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\DbEx.SqlServer\DbEx.SqlServer.csproj" />
     <ProjectReference Include="..\..\src\DbEx\DbEx.csproj" />
     <ProjectReference Include="..\DbEx.Test.OutboxConsole\DbEx.Test.OutboxConsole.csproj" />

--- a/tests/DbEx.Test.Console/Migrations/002-create-test-contact-type-table.sql
+++ b/tests/DbEx.Test.Console/Migrations/002-create-test-contact-type-table.sql
@@ -2,5 +2,7 @@
       [ContactTypeId] INT NOT NULL IDENTITY(1, 1) PRIMARY KEY,
       [Code] NVARCHAR (50) NOT NULL UNIQUE,
       [Text] VARCHAR (256) NOT NULL,
-      [SortOrder] INT NOT NULL
+      [SortOrder] INT NOT NULL,
+      [IsFlag] BIT NOT NULL DEFAULT 1,
+      [Number] BIGINT NULL
     )

--- a/tests/DbEx.Test.Console/Migrations/004a-create-test-contact-address-table.sql
+++ b/tests/DbEx.Test.Console/Migrations/004a-create-test-contact-address-table.sql
@@ -1,0 +1,6 @@
+﻿    CREATE TABLE [Test].[ContactAddress] (
+      [ContactAddressId] INT NOT NULL PRIMARY KEY,
+      [ContactId] INT NOT NULL,
+      [Street] NVARCHAR (200) NOT NULL,
+      CONSTRAINT [FK_Test_ContactAddress_Contact] FOREIGN KEY ([ContactId]) REFERENCES [Test].[Contact] ([ContactId])
+    )

--- a/tests/DbEx.Test.Console/Program.cs
+++ b/tests/DbEx.Test.Console/Program.cs
@@ -13,7 +13,9 @@ namespace DbEx.Test.Console
                 c.Args.AddSchemaOrder("Test", "Outbox");
                 c.Args.DataParserArgs.Parameter("DefaultName", "Bazza")
                                      .RefDataColumnDefault("SortOrder", i => i)
-                                     .ColumnDefault("*", "*", "TenantId", _ => "test-tenant");
+                                     .ColumnDefault("*", "*", "TenantId", _ => "test-tenant")
+                                     .TableNameMappings.Add("XTest", "XContactType", "Test", "ContactType", new() { { "XNumber", "Number" } })
+                                                       .Add("Test", "Addresses", "Test", "ContactAddress");
             })
             .RunAsync(args);
     }

--- a/tests/DbEx.Test.Console/Properties/launchSettings.json
+++ b/tests/DbEx.Test.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DbEx.Test.Console": {
       "commandName": "Project",
-      "commandLineArgs": "dropandall -p DefaultName=Greg"
+      "commandLineArgs": "dropandall"
     }
   }
 }

--- a/tests/DbEx.Test/DatabaseSchemaTest.cs
+++ b/tests/DbEx.Test/DatabaseSchemaTest.cs
@@ -41,7 +41,7 @@ namespace DbEx.Test
             Assert.AreEqual("[Test].[ContactType]", tab.QualifiedName);
             Assert.IsFalse(tab.IsAView);
             Assert.IsTrue(tab.IsRefData);
-            Assert.AreEqual(4, tab.Columns.Count);
+            Assert.AreEqual(6, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
             Assert.AreEqual("ContactType", tab.DotNetName);
             Assert.AreEqual("ContactTypes", tab.PluralName);

--- a/tests/DbEx.Test/SqlServerMigrationTest.cs
+++ b/tests/DbEx.Test/SqlServerMigrationTest.cs
@@ -171,6 +171,8 @@ namespace DbEx.Test
             m.Args.DataParserArgs.Parameters.Add("DefaultName", "Bazza");
             m.Args.DataParserArgs.RefDataColumnDefaults.Add("SortOrder", i => i);
             m.Args.DataParserArgs.ColumnDefaults.Add(new DataParserColumnDefault("*", "*", "TenantId", _ => "test-tenant"));
+            m.Args.DataParserArgs.TableNameMappings.Add("XTest", "XContactType", "Test", "ContactType", new() { { "XNumber", "Number" } })
+                                                   .Add("Test", "Addresses", "Test", "ContactAddress");
 
             var r = await m.MigrateAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
- *Enhancement:* `DataParser.ParseJsonAsync` added to support JSON data file parsing in addition to the existing YAML. Files (embedded resources) can be mixed and matched as required.
- *Enhancement:* `DataParser` supports specified schema of `*` to provide `DataConfig` that is applied to all tables in the YAML/JSON file.
- *Enhancement:* `DataParser` supports hierarchical data (i.e parent/child) where the child row(s) are specified as a parent column value (must be an array). Will also attempt to update the child related column from the parent primary key where not specified to simplify specification.
- *Fixed:* `DataParser` supports `bit` values of `0` and `1`, in addition to `false` and `true` respectively.
- *Fixed:* `DataParser` constraint of table only being specified once in the YAML/JSON file has been removed; this is now supported. The underlying database insert or merge operations will be consolidated and executed in the sequence of initial specification.
