### PR TITLE
v2.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v2.3.12
+- *Fixed:* The `OutBox.EventOutbox` table clustered/non-clustered indexes changed to simplify default implementation. Implementors of this capability should review the indexing, etc., based on usage to optimize. 
+	- _Note:_ it is also expected that the _Outbox_ tables are regularly purged, i.e. dequeued events should be removed. This is the responsibility of the implementor to perform as required.
+
 ## v2.3.11
 - *Enhancement:* `DataParser.ParseJsonAsync` added to support JSON data file parsing in addition to the existing YAML. Files (embedded resources) can be mixed and matched as required.
 - *Enhancement:* `DataParser` supports specified schema of `*` to provide `DataConfig` that is applied to all tables in the YAML/JSON file.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.3.11</Version>
+    <Version>2.3.12</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.SqlServer/Templates/TableEventOutbox_sql.hbs
+++ b/src/DbEx.SqlServer/Templates/TableEventOutbox_sql.hbs
@@ -6,10 +6,10 @@ CREATE TABLE [{{OutboxSchema}}].[{{OutboxTable}}] (
    */
 
 {{/unless}}
-  [{{OutboxTable}}Id] BIGINT IDENTITY (1, 1) NOT NULL PRIMARY KEY NONCLUSTERED ([{{OutboxTable}}Id] ASC),
+  [{{OutboxTable}}Id] BIGINT IDENTITY (1, 1) NOT NULL PRIMARY KEY,
   [PartitionKey] NVARCHAR(127) NULL,
   [Destination] NVARCHAR(127) NULL,
   [EnqueuedDate] DATETIME2 NOT NULL,
   [DequeuedDate] DATETIME2 NULL,
-  CONSTRAINT [IX_{{OutboxSchema}}_{{OutboxTable}}_DequeuedDate] UNIQUE CLUSTERED ([PartitionKey], [Destination], [DequeuedDate], [{{OutboxTable}}Id])
+  INDEX [IX_{{OutboxSchema}}_{{OutboxTable}}_DequeuedDate] ([DequeuedDate], [{{OutboxTable}}Id])
 );

--- a/tests/DbEx.Test.OutboxConsole/Migrations/101-create-outbox-eventoutbox-table.sql
+++ b/tests/DbEx.Test.OutboxConsole/Migrations/101-create-outbox-eventoutbox-table.sql
@@ -3,10 +3,10 @@ CREATE TABLE [Outbox].[EventOutbox] (
    * This is automatically generated; any changes will be lost.
    */
 
-  [EventOutboxId] BIGINT IDENTITY (1, 1) NOT NULL PRIMARY KEY NONCLUSTERED ([EventOutboxId] ASC),
+  [EventOutboxId] BIGINT IDENTITY (1, 1) NOT NULL PRIMARY KEY,
   [PartitionKey] NVARCHAR(127) NULL,
   [Destination] NVARCHAR(127) NULL,
   [EnqueuedDate] DATETIME2 NOT NULL,
   [DequeuedDate] DATETIME2 NULL,
-  CONSTRAINT [IX_Outbox_EventOutbox_DequeuedDate] UNIQUE CLUSTERED ([PartitionKey], [Destination], [DequeuedDate], [EventOutboxId])
+  INDEX [IX_Outbox_EventOutbox_DequeuedDate] ([DequeuedDate], [EventOutboxId])
 );


### PR DESCRIPTION
- *Fixed:* The `OutBox.EventOutbox` table clustered/non-clustered indexes changed to simplify default implementation. Implementors of this capability should review the indexing, etc., based on usage to optimize. 
	- _Note:_ it is also expected that the _Outbox_ tables are regularly purged, i.e. dequeued events should be removed. This is the responsibility of the implementor to perform as required.
