### PR TITLE
v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v2.5.1
+- *Fixed:* Updated `CoreEx` to version `3.15.0`.
+- *Fixed* Simplify event outbox C# code-generation templates for primary constructor usage.
+
 ## v2.5.0
 - *Enhancement:* Added [PostgreSQL](https://www.postgresql.org/) database migrations support.
 - *Enhancement:* Added `DateOnly` and `TimeOnly` support (requires `net7.0`+) (see also `MigrationArgs.EmitDotNetDateOnly` and `MigrationArgs.EmitDotNetTimeOnly` to explicitly enable).

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/DbEx.MySql.csproj
+++ b/src/DbEx.MySql/DbEx.MySql.csproj
@@ -41,8 +41,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.12.0" />
-    <PackageReference Include="dbup-mysql" Version="5.0.40" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.15.0" />
+    <PackageReference Include="dbup-mysql" Version="5.0.44" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DbEx.Postgres/DbEx.Postgres.csproj
+++ b/src/DbEx.Postgres/DbEx.Postgres.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.12.0" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.15.0" />
     <PackageReference Include="dbup-postgresql" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx.SqlServer/DbEx.SqlServer.csproj
+++ b/src/DbEx.SqlServer/DbEx.SqlServer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.12.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
     <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx.SqlServer/Templates/EventOutboxDequeue_cs.hbs
+++ b/src/DbEx.SqlServer/Templates/EventOutboxDequeue_cs.hbs
@@ -13,16 +13,11 @@ namespace {{NamespaceOutbox}}.Data;
 /// <summary>
 /// Provides the <see cref="EventSendData"/> <see cref="IDatabase">database</see> <i>outbox enqueue</i> <see cref="SendAsync(EventSendData[])"/>. 
 /// </summary>
-public sealed class EventOutboxDequeue : EventOutboxDequeueBase
+/// <param name="database">The <see cref="IDatabase"/>.</param>
+/// <param name="eventSender">The <see cref="IEventSender"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+public sealed class EventOutboxDequeue(IDatabase database, IEventSender eventSender, ILogger<EventOutboxDequeue> logger) : EventOutboxDequeueBase(database, eventSender, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EventOutboxDequeue"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="IDatabase"/>.</param>
-    /// <param name="eventSender">The <see cref="IEventSender"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public EventOutboxDequeue(IDatabase database, IEventSender eventSender, ILogger<EventOutboxDequeue> logger) : base(database, eventSender, logger) { }
-
     /// <inheritdoc/>
     protected override string DequeueStoredProcedure => "[{{OutboxSchema}}].[{{OutboxDequeueStoredProcedure}}]";
 }{{#if Root.PreprocessorDirectives}}

--- a/src/DbEx.SqlServer/Templates/EventOutboxEnqueue_cs.hbs
+++ b/src/DbEx.SqlServer/Templates/EventOutboxEnqueue_cs.hbs
@@ -13,15 +13,10 @@ namespace {{NamespaceOutbox}}.Data;
 /// <summary>
 /// Provides the <see cref="EventSendData"/> <see cref="IDatabase">database</see> <i>outbox enqueue</i> <see cref="SendAsync(EventSendData[])"/>. 
 /// </summary>
-public sealed class EventOutboxEnqueue : EventOutboxEnqueueBase
+/// <param name="database">The <see cref="IDatabase"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+public sealed class EventOutboxEnqueue(IDatabase database, ILogger<EventOutboxEnqueue> logger) : EventOutboxEnqueueBase(database, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EventOutboxEnqueue"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="IDatabase"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public EventOutboxEnqueue(IDatabase database, ILogger<EventOutboxEnqueue> logger) : base(database, logger) { }
-
     /// <inheritdoc/>
     protected override string DbTvpTypeName => "[{{OutboxSchema}}].[udt{{OutboxTable}}List]";
 

--- a/src/DbEx/DbEx.csproj
+++ b/src/DbEx/DbEx.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.12.0" />
-    <PackageReference Include="OnRamp" Version="2.0.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.15.0" />
+    <PackageReference Include="OnRamp" Version="2.2.0" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tests/DbEx.Test.OutboxConsole/DbEx.Test.OutboxConsole.csproj
+++ b/tests/DbEx.Test.OutboxConsole/DbEx.Test.OutboxConsole.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/DbEx.Test.OutboxConsole/Generated/EventOutboxDequeue.cs
+++ b/tests/DbEx.Test.OutboxConsole/Generated/EventOutboxDequeue.cs
@@ -7,16 +7,11 @@ namespace DbEx.Test.OutboxConsole.Data;
 /// <summary>
 /// Provides the <see cref="EventSendData"/> <see cref="IDatabase">database</see> <i>outbox enqueue</i> <see cref="SendAsync(EventSendData[])"/>. 
 /// </summary>
-public sealed class EventOutboxDequeue : EventOutboxDequeueBase
+/// <param name="database">The <see cref="IDatabase"/>.</param>
+/// <param name="eventSender">The <see cref="IEventSender"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+public sealed class EventOutboxDequeue(IDatabase database, IEventSender eventSender, ILogger<EventOutboxDequeue> logger) : EventOutboxDequeueBase(database, eventSender, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EventOutboxDequeue"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="IDatabase"/>.</param>
-    /// <param name="eventSender">The <see cref="IEventSender"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public EventOutboxDequeue(IDatabase database, IEventSender eventSender, ILogger<EventOutboxDequeue> logger) : base(database, eventSender, logger) { }
-
     /// <inheritdoc/>
     protected override string DequeueStoredProcedure => "[Outbox].[spEventOutboxDequeue]";
 }

--- a/tests/DbEx.Test.OutboxConsole/Generated/EventOutboxEnqueue.cs
+++ b/tests/DbEx.Test.OutboxConsole/Generated/EventOutboxEnqueue.cs
@@ -7,15 +7,10 @@ namespace DbEx.Test.OutboxConsole.Data;
 /// <summary>
 /// Provides the <see cref="EventSendData"/> <see cref="IDatabase">database</see> <i>outbox enqueue</i> <see cref="SendAsync(EventSendData[])"/>. 
 /// </summary>
-public sealed class EventOutboxEnqueue : EventOutboxEnqueueBase
+/// <param name="database">The <see cref="IDatabase"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+public sealed class EventOutboxEnqueue(IDatabase database, ILogger<EventOutboxEnqueue> logger) : EventOutboxEnqueueBase(database, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EventOutboxEnqueue"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="IDatabase"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public EventOutboxEnqueue(IDatabase database, ILogger<EventOutboxEnqueue> logger) : base(database, logger) { }
-
     /// <inheritdoc/>
     protected override string DbTvpTypeName => "[Outbox].[udtEventOutboxList]";
 

--- a/tests/DbEx.Test/DbEx.Test.csproj
+++ b/tests/DbEx.Test/DbEx.Test.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- *Fixed:* Updated `CoreEx` to version `3.15.0`.
- *Fixed* Simplify event outbox C# code-generation templates for primary constructor usage.