### PR TITLE
v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v2.5.2
+- *Fixed:* Updated `CoreEx` to version `3.18.0`.
+  - Includes removal of `Azure.Identity` dependency; related to `https://github.com/advisories/GHSA-wvxc-855f-jvrv`.
+
 ## v2.5.1
 - *Fixed:* Updated `CoreEx` to version `3.15.0`.
 - *Fixed* Simplify event outbox C# code-generation templates for primary constructor usage.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.5.1</Version>
+    <Version>2.5.2</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/DbEx.MySql.csproj
+++ b/src/DbEx.MySql/DbEx.MySql.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.18.0" />
     <PackageReference Include="dbup-mysql" Version="5.0.44" />
   </ItemGroup>
 

--- a/src/DbEx.Postgres/DbEx.Postgres.csproj
+++ b/src/DbEx.Postgres/DbEx.Postgres.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.18.0" />
     <PackageReference Include="dbup-postgresql" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx.SqlServer/DbEx.SqlServer.csproj
+++ b/src/DbEx.SqlServer/DbEx.SqlServer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.0" />
     <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx/DbEx.csproj
+++ b/src/DbEx/DbEx.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.18.0" />
     <PackageReference Include="OnRamp" Version="2.2.0" />
   </ItemGroup>
 

--- a/tests/DbEx.Test/SqlServerOutboxTest.cs
+++ b/tests/DbEx.Test/SqlServerOutboxTest.cs
@@ -246,10 +246,10 @@ namespace DbEx.Test
             eoe.SetPrimaryEventSender(new TestSenderFail());
             await eoe.SendAsync(new EventSendData[] 
             { 
-                new EventSendData { Id = "1", PartitionKey = null, Destination = "A" },
-                new EventSendData { Id = "2", PartitionKey = null, Destination = "B" },
-                new EventSendData { Id = "3", PartitionKey = null, Destination = "A" },
-                new EventSendData { Id = "4", PartitionKey = null, Destination = "B" }
+                new() { Id = "1", PartitionKey = null, Destination = "A" },
+                new() { Id = "2", PartitionKey = null, Destination = "B" },
+                new() { Id = "3", PartitionKey = null, Destination = "A" },
+                new() { Id = "4", PartitionKey = null, Destination = "B" }
             }).ConfigureAwait(false);
 
             var ims = new InMemorySender();
@@ -265,11 +265,15 @@ namespace DbEx.Test
 
         private class TestSender : IEventSender
         {
+            public event EventHandler AfterSend;
+
             public Task SendAsync(IEnumerable<EventSendData> events, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
 
         private class TestSenderFail : IEventSender
         {
+            public event EventHandler AfterSend;
+
             public Task SendAsync(IEnumerable<EventSendData> events, CancellationToken cancellationToken = default)
             {
                 var elist = events.ToArray();


### PR DESCRIPTION
- *Fixed:* Updated `CoreEx` to version `3.18.0`.
  - Includes removal of `Azure.Identity` dependency; related to `https://github.com/advisories/GHSA-wvxc-855f-jvrv`.