### PR TITLE
v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v2.5.3
+- *Fixed:* Updated `CoreEx` to version `3.20.0`.
+- *Fixed:* Fixed logging of SQL statements to include the source: `FILE`, `RES` (embedded resource) or `SQL` (specified statement).
+
 ## v2.5.2
 - *Fixed:* Updated `CoreEx` to version `3.18.0`.
   - Includes removal of `Azure.Identity` dependency; related to `https://github.com/advisories/GHSA-wvxc-855f-jvrv`.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.5.2</Version>
+    <Version>2.5.3</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/DbEx.MySql.csproj
+++ b/src/DbEx.MySql/DbEx.MySql.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.20.0" />
     <PackageReference Include="dbup-mysql" Version="5.0.44" />
   </ItemGroup>
 

--- a/src/DbEx.Postgres/DbEx.Postgres.csproj
+++ b/src/DbEx.Postgres/DbEx.Postgres.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.20.0" />
     <PackageReference Include="dbup-postgresql" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx.SqlServer/DbEx.SqlServer.csproj
+++ b/src/DbEx.SqlServer/DbEx.SqlServer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.20.0" />
     <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx/DbEx.csproj
+++ b/src/DbEx/DbEx.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.20.0" />
     <PackageReference Include="OnRamp" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/DbEx/Migration/DatabaseMigrationBase.cs
+++ b/src/DbEx/Migration/DatabaseMigrationBase.cs
@@ -343,7 +343,7 @@ namespace DbEx.Migration
                 }
 
                 if (includeExecutionLogging)
-                    Logger.LogInformation("{Content}", $"    {script.Name}{(string.IsNullOrEmpty(script.Tag) ? "" : $" > {script.Tag}")}");
+                    Logger.LogInformation("{Content}", $"    {script.Name} ({script.Source}){(string.IsNullOrEmpty(script.Tag) ? "" : $" > {script.Tag}")}");
 
                 try
                 {
@@ -748,7 +748,7 @@ namespace DbEx.Migration
                     Logger.LogInformation("{Content}", $"** Executing: {item.ResourceName}");
 
                     var ss = new DatabaseMigrationScript(this, item.Assembly, item.ResourceName) { RunAlways = true };
-                    if (!await ExecuteScriptsAsync(new DatabaseMigrationScript[] { ss }, false, cancellationToken).ConfigureAwait(false))
+                    if (!await ExecuteScriptsAsync([ss], false, cancellationToken).ConfigureAwait(false))
                         return false;
                 }
                 else
@@ -865,7 +865,6 @@ namespace DbEx.Migration
         /// </summary>
         private async Task<bool> CreateScriptInternalAsync(string? name, IDictionary<string, string?>? parameters, CancellationToken cancellationToken)
         {
-
             name ??= "Default";
             var rn = $"Script{name}_sql";
 

--- a/src/DbEx/Migration/DatabaseMigrationScript.cs
+++ b/src/DbEx/Migration/DatabaseMigrationScript.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
 
 using CoreEx;
-using System;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -47,9 +46,8 @@ namespace DbEx.Migration
         /// Initializes a new instance of the <see cref="DatabaseMigrationScript"/> class for the specified <paramref name="sql"/>.
         /// </summary>
         /// <param name="databaseMigation">The owning <see cref="DatabaseMigrationBase"/>.</param>
-        /// <param name="sql"></param>
+        /// <param name="sql">The SQL statement.</param>
         /// <param name="name">The sql name.</param>
-        /// <exception cref="ArgumentNullException"></exception>
         public DatabaseMigrationScript(DatabaseMigrationBase databaseMigation, string sql, string name)
         {
             DatabaseMigration = databaseMigation.ThrowIfNull(nameof(databaseMigation));
@@ -82,6 +80,11 @@ namespace DbEx.Migration
         /// Gets or sets additional tag text to output to the log.
         /// </summary>
         public string? Tag { get; set; }
+
+        /// <summary>
+        /// Gets the underlying SQL statement source.
+        /// </summary>
+        public string Source => _assembly is not null ? "RES" : (_file is not null ? "FILE" : "SQL");
 
         /// <summary>
         /// Gets the resource or file <see cref="System.IO.StreamReader"/>.


### PR DESCRIPTION
- *Fixed:* Updated `CoreEx` to version `3.20.0`.
- *Fixed:* Fixed logging of SQL statements to include the source: `FILE`, `RES` (embedded resource) or `SQL` (specified statement).