### PR TITLE
v2.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v2.5.4
+- *Fixed:* Updated `CoreEx` to version `3.21.0`.
+- *Fixed:* Updated `DataParser` to set column with JSON (`JsonElement.GetRawText`) value versus throwing an exception when the JSON is an object or an array.
+
 ## v2.5.3
 - *Fixed:* Updated `CoreEx` to version `3.20.0`.
 - *Fixed:* Fixed logging of SQL statements to include the source: `FILE`, `RES` (embedded resource) or `SQL` (specified statement).

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.5.3</Version>
+    <Version>2.5.4</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/DbEx.MySql.csproj
+++ b/src/DbEx.MySql/DbEx.MySql.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.21.0" />
     <PackageReference Include="dbup-mysql" Version="5.0.44" />
   </ItemGroup>
 

--- a/src/DbEx.Postgres/DbEx.Postgres.csproj
+++ b/src/DbEx.Postgres/DbEx.Postgres.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.21.0" />
     <PackageReference Include="dbup-postgresql" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx.SqlServer/DbEx.SqlServer.csproj
+++ b/src/DbEx.SqlServer/DbEx.SqlServer.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.21.0" />
     <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx/DbEx.csproj
+++ b/src/DbEx/DbEx.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.21.0" />
     <PackageReference Include="OnRamp" Version="2.2.0" />
   </ItemGroup>
 

--- a/tests/DbEx.Test.Console/Data/Data.yaml
+++ b/tests/DbEx.Test.Console/Data/Data.yaml
@@ -8,6 +8,6 @@
   - { ContactId: 2, ContactType: I, Name: Jane, Phone: 1234, Addresses: [ { ContactAddressId: 20, ContactId: 2, Street: "1 Main Street" } ] }
 - ^Person:
   - { PersonId: 88, Name: '^(DbEx.Test.Console.RuntimeValues.Name, DbEx.Test.Console)' }
-  - { Name: '^(DefaultName)' }
+  - { Name: '^(DefaultName)', AddressJson: { Street: "Main St", City: "Maine" }, NicknamesJson: ["Gaz", "Baz"] }
 - $Gender:
   - X: Not specified

--- a/tests/DbEx.Test.Console/Migrations/006-create-test-person-table.sql
+++ b/tests/DbEx.Test.Console/Migrations/006-create-test-person-table.sql
@@ -1,6 +1,8 @@
 ﻿    CREATE TABLE [Test].[Person] (
       [PersonId] UNIQUEIDENTIFIER NOT NULL DEFAULT (NEWSEQUENTIALID()) PRIMARY KEY,
       [Name] NVARCHAR (200) NOT NULL,
+      [NicknamesJson] NVARCHAR (500) NULL,
+      [AddressJson] NVARCHAR (500) NULL,
       [CreatedBy] NVARCHAR (200) NULL,
       [CreatedDate] DATETIME2 NULL,
       [UpdatedBy] NVARCHAR (200) NULL,

--- a/tests/DbEx.Test/DatabaseSchemaTest.cs
+++ b/tests/DbEx.Test/DatabaseSchemaTest.cs
@@ -331,7 +331,7 @@ namespace DbEx.Test
             Assert.AreEqual("[Test].[Person]", tab.QualifiedName);
             Assert.IsFalse(tab.IsAView);
             Assert.IsFalse(tab.IsRefData);
-            Assert.AreEqual(6, tab.Columns.Count);
+            Assert.AreEqual(8, tab.Columns.Count);
             Assert.AreEqual(1, tab.PrimaryKeyColumns.Count);
             Assert.AreEqual("Person", tab.DotNetName);
             Assert.AreEqual("People", tab.PluralName);

--- a/tests/DbEx.Test/DbEx.Test.csproj
+++ b/tests/DbEx.Test/DbEx.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">

--- a/tests/DbEx.Test/SqlServerMigrationTest.cs
+++ b/tests/DbEx.Test/SqlServerMigrationTest.cs
@@ -124,6 +124,8 @@ namespace DbEx.Test
                 Name = dr.GetValue<string>("Name"),
                 CreatedBy = dr.GetValue<string>("CreatedBy"),
                 CreatedDate = dr.GetValue<DateTime>("CreatedDate"),
+                AddressJson = dr.GetValue<string>("AddressJson"),
+                NicknamesJson = dr.GetValue<string>("NicknamesJson")
             }).ConfigureAwait(false)).ToList();
 
             Assert.AreEqual(3, res.Count);
@@ -138,6 +140,8 @@ namespace DbEx.Test
             Assert.AreEqual("Bazza", row2.Name);
             Assert.AreEqual(m.Args.DataParserArgs.UserName, row2.CreatedBy);
             Assert.AreEqual(m.Args.DataParserArgs.DateTimeNow, row2.CreatedDate);
+            Assert.AreEqual("{\"Street\": \"Main St\", \"City\": \"Maine\"}", row2.AddressJson);
+            Assert.AreEqual("[\"Gaz\", \"Baz\"]", row2.NicknamesJson);
 
             // Check that the stored procedure script was migrated and works!
             res = (await db.StoredProcedure("[Test].[spGetContact]").Param("@ContactId", 2).SelectQueryAsync(dr => new


### PR DESCRIPTION
- *Fixed:* Updated `CoreEx` to version `3.21.0`.
- *Fixed:* Updated `DataParser` to set column with JSON (`JsonElement.GetRawText`) value versus throwing an exception when the JSON is an object or an array.