### PR TITLE
v2.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v2.5.5
+- *Fixed:* Updated `DataParser` to set column with a guid representation of an integer where specified using shorthand notation; i.e. replace `^n` values where `n` is an integer with a guid equivalent; e.g. `^1` will be converted to `00000001-0000-0000-0000-000000000000`. A new `DataParserArgs.ReplaceShorthandGuids` had been added to control this behavior (defaults to `true`).
+
 ## v2.5.4
 - *Fixed:* Updated `CoreEx` to version `3.21.0`.
 - *Fixed:* Updated `DataParser` to set column with JSON (`JsonElement.GetRawText`) value versus throwing an exception when the JSON is an object or an array.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.5.4</Version>
+    <Version>2.5.5</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx/Migration/Data/DataParser.cs
+++ b/src/DbEx/Migration/Data/DataParser.cs
@@ -317,6 +317,8 @@ namespace DbEx.Migration.Data
 
                 throw new DataParserException(msg);
             }
+            else if (ParserArgs.ReplaceShorthandGuids && int.TryParse(value[1..], out var i))
+                return new Guid(i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
             else
                 return value;
         }

--- a/src/DbEx/Migration/Data/DataParserArgs.cs
+++ b/src/DbEx/Migration/Data/DataParserArgs.cs
@@ -132,6 +132,11 @@ namespace DbEx.Migration.Data
         public DataParserTableNameMappings TableNameMappings { get; } = [];
 
         /// <summary>
+        /// Indiates whether to replace '<c>^n</c>' values where '<c>n</c>' is an integer with a <see cref="Guid"/> equivalent; e.g. '<c>^1</c>' will be '<c>00000001-0000-0000-0000-000000000000</c>'
+        /// </summary>
+        public bool ReplaceShorthandGuids { get; set; } = true;
+
+        /// <summary>
         /// Copy and replace from <paramref name="args"/>.
         /// </summary>
         /// <param name="args">The <see cref="DataParserArgs"/> to copy from.</param>
@@ -152,6 +157,7 @@ namespace DbEx.Migration.Data
             args.Parameters.ForEach(x => Parameters.Add(x.Key, x.Value));
             TableNameMappings.Clear();
             args.TableNameMappings.ForEach(x => TableNameMappings.Add(x.Key.ParsedSchema, x.Key.ParsedTable, x.Value.Schema, x.Value.Table, x.Value.ColumnMappings));
+            ReplaceShorthandGuids = args.ReplaceShorthandGuids;
         }
     }
 }

--- a/tests/DbEx.Test.Console/Data/Data.yaml
+++ b/tests/DbEx.Test.Console/Data/Data.yaml
@@ -7,7 +7,7 @@
   - { ContactId: 1, ContactType: E, Gender: M, Name: Bob, DateOfBirth: 2001-10-22, Addresses: [ { ContactAddressId: 10, Street: "1 Main Street" } ] }
   - { ContactId: 2, ContactType: I, Name: Jane, Phone: 1234, Addresses: [ { ContactAddressId: 20, ContactId: 2, Street: "1 Main Street" } ] }
 - ^Person:
-  - { PersonId: 88, Name: '^(DbEx.Test.Console.RuntimeValues.Name, DbEx.Test.Console)' }
+  - { PersonId: ^88, Name: '^(DbEx.Test.Console.RuntimeValues.Name, DbEx.Test.Console)' }
   - { Name: '^(DefaultName)', AddressJson: { Street: "Main St", City: "Maine" }, NicknamesJson: ["Gaz", "Baz"] }
 - $Gender:
   - X: Not specified


### PR DESCRIPTION
- *Fixed:* Updated `DataParser` to set column with a guid representation of an integer where specified using shorthand notation; i.e. replace `^n` values where `n` is an integer with a guid equivalent; e.g. `^1` will be converted to `00000001-0000-0000-0000-000000000000`. A new `DataParserArgs.ReplaceShorthandGuids` had been added to control this behavior (defaults to `true`).