### PR TITLE
v2.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v2.5.8
+- *Fixed:* SQL Server `data` merge statement fixed to include the `TenantIdColumn` where applicable to avoid possible duplicate key.
+
 ## v2.5.7
 - *Fixed:* Corrected issue introduced in version `2.5.5` where some strings were being incorrectly converted to a guid.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.5.7</Version>
+    <Version>2.5.8</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.SqlServer/Resources/DatabaseData_sql.hbs
+++ b/src/DbEx.SqlServer/Resources/DatabaseData_sql.hbs
@@ -15,7 +15,7 @@ INSERT INTO #temp ({{#each Columns}}[{{Name}}]{{#unless @last}}, {{/unless}}{{/e
 
 MERGE INTO [{{Schema}}].[{{Name}}] WITH (HOLDLOCK) as [t]
   USING (SELECT {{#each Columns}}[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}} FROM #temp) AS [s] 
-    ON ({{#if IsRefData}}[s].[{{DbTable.RefDataCodeColumn.Name}}] = [t].[{{DbTable.RefDataCodeColumn.Name}}]{{else}}{{#each PrimaryKeyColumns}}{{#unless @first}} ON {{/unless}}[s].[{{Name}}] = [t].[{{Name}}]{{/each}}{{/if}})
+    ON ({{#if IsRefData}}[s].[{{DbTable.RefDataCodeColumn.Name}}] = [t].[{{DbTable.RefDataCodeColumn.Name}}]{{else}}{{#each PrimaryKeyColumns}}{{#unless @first}} ON {{/unless}}[s].[{{Name}}] = [t].[{{Name}}]{{/each}}{{/if}}{{#ifval DbTable.TenantIdColumn}} AND [s].[{{DbTable.TenantIdColumn.Name}}] = [t].[{{DbTable.TenantIdColumn.Name}}]{{/ifval}})
   WHEN MATCHED AND EXISTS (
       SELECT {{#each MergeMatchColumns}}[s].[{{Name}}]{{#unless @last}}, {{/unless}}{{/each}}
       EXCEPT

--- a/tests/DbEx.Test.Console/Data/Data.yaml
+++ b/tests/DbEx.Test.Console/Data/Data.yaml
@@ -11,3 +11,8 @@
   - { Name: '^(DefaultName)', AddressJson: { Street: "Main St", City: "Maine" }, NicknamesJson: ["Gaz", "Baz"] }
 - $Gender:
   - X: Not specified
+- $Status:
+  - { Code: A, Text: Active, TenantId: ^88 }
+  - { Code: I, Text: Inactive, TenantId: ^88 }  
+  - { Code: A, Text: Active, TenantId: ^99 }
+  - { Code: I, Text: Inactive, TenantId: ^99 } 

--- a/tests/DbEx.Test.Console/Data/Data2.yaml
+++ b/tests/DbEx.Test.Console/Data/Data2.yaml
@@ -1,0 +1,7 @@
+﻿Test:
+# Specified again, merge should not result in duplicate error
+- $Status:
+  - { Code: A, Text: Active, TenantId: ^88 }
+  - { Code: I, Text: Inactive, TenantId: ^88 }  
+  - { Code: A, Text: Active, TenantId: ^99 }
+  - { Code: I, Text: Inactive, TenantId: ^99 } 

--- a/tests/DbEx.Test.Console/DbEx.Test.Console.csproj
+++ b/tests/DbEx.Test.Console/DbEx.Test.Console.csproj
@@ -13,7 +13,9 @@
 
   <ItemGroup>
     <None Remove="Data\ContactType.json" />
+    <None Remove="Data\Data2.yaml" />
     <None Remove="Migrations\004a-create-test-contact-address-table.sql" />
+    <None Remove="Migrations\007-create-test-status-table.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DbEx.Test.Console/Migrations/007-create-test-status-table.sql
+++ b/tests/DbEx.Test.Console/Migrations/007-create-test-status-table.sql
@@ -1,0 +1,11 @@
+﻿CREATE TABLE [Test].[Status] (
+    [StatusId] UNIQUEIDENTIFIER NOT NULL DEFAULT (NEWSEQUENTIALID()) PRIMARY KEY,
+    [Code] NVARCHAR (50) NOT NULL,
+    [Text] VARCHAR (256) NOT NULL,
+    [CreatedBy] NVARCHAR (50) NULL,
+    [CreatedDate] DATETIME2 NULL,
+    [UpdatedBy] NVARCHAR (50) NULL,
+    [UpdatedDate] DATETIME2 NULL,
+    [TenantId] NVARCHAR(50) NOT NULL,
+    UNIQUE ([TenantId], [Code])
+)


### PR DESCRIPTION
- *Fixed:* SQL Server `data` merge statement fixed to include the `TenantIdColumn` where applicable to avoid possible duplicate key.