### PR TITLE
v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 Represents the **NuGet** versions.
 
+## v2.7.0
+- *Enhancement:* Require a means to add an explicitly named resource-based script outside of the automatic convention-based discovery; see new `MigrationArgs.AddScript`.
+- *Enhancement:* Moving the [_Beef_](https://github.com/Avanade/beef)-based standardized SQL Server scripts (functions and stored procedures) to _DbEx_ to enable greater usage. New `MigrationArgs.IncludeExtendedSchemaScripts` extension method will add (leverages new `MigrationArgs.AddScript`).
+- *Enhancement:* Added PostgreSQL equivalent standardized SQL Server scripts (functions and stored procedures).
+- *Enhancement:* Added command-line option `-dso|--drop-schema-objects` to set `MigrationArgs.DropSchemaObjects` directly from the console.
+
 ## v2.6.1
-- *Fixed:* Added `MigrationCommand.CreateMigrateAndCodeGen`. This can be useful in development scenarios where the `CodeGen` phase results in a new migration script that needs to be applied before any corresponding `Schema` operations are performed; in this case, a secondary 
+- *Fixed:* Added `MigrationCommand.CreateMigrateAndCodeGen`. This can be useful in development scenarios where the `CodeGen` phase results in a new migration script that needs to be applied before any corresponding `Schema` operations are performed; in this case, a secondary migration will be required.
 
 ## v2.6.0
 - *Enhancement:* Added a `DbColumnSchema.SqlType2` that does _not_ include nullability.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.6.1</Version>
+    <Version>2.7.0</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/DbEx.MySql.csproj
+++ b/src/DbEx.MySql/DbEx.MySql.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.25.6" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.27.0" />
     <PackageReference Include="dbup-mysql" Version="5.0.44" />
   </ItemGroup>
 

--- a/src/DbEx.Postgres/Console/MigrationArgsExtensions.cs
+++ b/src/DbEx.Postgres/Console/MigrationArgsExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+using DbEx.Migration;
+using System.Linq;
+
+namespace DbEx.Postgres.Console
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="MigrationArgs"/>.
+    /// </summary>
+    public static class MigrationArgsExtensions
+    {
+        /// <summary>
+        /// Include the Postgres extended <b>Schema</b> scripts (stored procedures and functions) from <see href="https://github.com/Avanade/DbEx/tree/main/src/DbEx.Postgres/Resources/ExtendedSchema"/>.
+        /// </summary>
+        /// <param name="args">The <see cref="MigrationArgs"/>.</param>
+        /// <returns>The <see cref="MigrationArgs"/> to support fluent-style method-chaining.</returns>
+        public static MigrationArgs IncludeExtendedSchemaScripts(this MigrationArgs args)
+        {
+            AddExtendedSchemaScripts(args);
+            return args;
+        }
+
+        /// <summary>
+        /// Include the Postgres extended <b>Schema</b> scripts (stored procedures and functions) from <see href="https://github.com/Avanade/DbEx/tree/main/src/DbEx.Postgres/Resources/ExtendedSchema"/>.
+        /// </summary>
+        /// <param name="args">The <see cref="MigrationArgs"/>.</param>
+        /// <returns>The <see cref="MigrationArgs"/> to support fluent-style method-chaining.</returns>
+        public static void AddExtendedSchemaScripts<TArgs>(TArgs args) where TArgs : MigrationArgsBase<TArgs>
+        {
+            foreach (var rn in typeof(MigrationArgsExtensions).Assembly.GetManifestResourceNames().Where(x => x.StartsWith("DbEx.Postgres.Resources.ExtendedSchema.") && x.EndsWith(".sql")))
+            {
+                args.AddScript(MigrationCommand.Schema, typeof(MigrationArgsExtensions).Assembly, rn);
+            }
+        }
+    }
+}

--- a/src/DbEx.Postgres/DbEx.Postgres.csproj
+++ b/src/DbEx.Postgres/DbEx.Postgres.csproj
@@ -31,6 +31,18 @@
     <None Remove="Resources\JournalCreate.sql" />
     <None Remove="Resources\JournalExists.sql" />
     <None Remove="Resources\JournalPrevious.sql" />
+    <None Remove="Resources\ExtendedSchema\Functions\fn_get_tenant_id.sql" />
+    <None Remove="Resources\ExtendedSchema\Functions\fn_get_timestamp.sql" />
+    <None Remove="Resources\ExtendedSchema\Functions\fn_get_username.sql" />
+    <None Remove="Resources\ExtendedSchema\Functions\fn_get_user_id.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\sp_set_session_context.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\sp_throw_authorization_exception.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\sp_throw_business_exception.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\sp_throw_concurrency_exception.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\sp_throw_conflict_exception.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\sp_throw_duplicate_exception.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\sp_throw_not_found_exception.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\sp_throw_validation_exception.sql" />
     <None Remove="Resources\ScriptAlter_sql.hbs" />
     <None Remove="Resources\ScriptCreate_sql.hbs" />
     <None Remove="Resources\ScriptDefault_sql.hbs" />
@@ -42,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.25.6" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.27.0" />
     <PackageReference Include="dbup-postgresql" Version="5.0.40" />
   </ItemGroup>
 

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Functions/fn_get_tenant_id.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Functions/fn_get_tenant_id.sql
@@ -1,0 +1,19 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR REPLACE FUNCTION fn_get_tenant_id(
+  "Override" TEXT = NULL
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE "TenantId" TEXT;
+BEGIN
+  IF "Override" IS NULL THEN
+ 	"TenantId" := current_setting('Session.TenantId', true);
+  ELSE
+ 	"TenantId" := "Override";
+  END IF;
+
+  RETURN "TenantId";
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Functions/fn_get_timestamp.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Functions/fn_get_timestamp.sql
@@ -1,0 +1,23 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR REPLACE FUNCTION fn_get_timestamp(
+  "Override" TIMESTAMP WITH TIME ZONE = NULL
+)
+RETURNS TIMESTAMP WITH TIME ZONE
+LANGUAGE plpgsql
+AS $$
+DECLARE "Timestamp" TIMESTAMP WITH TIME ZONE;
+BEGIN
+  "Timestamp" := CURRENT_TIMESTAMP;
+  IF "Override" IS NULL THEN
+ 	"Timestamp" := to_timestamp(current_setting('Session.Timestamp', true), 'YYYY-MM-DD"T"HH24:MI:SS.FF6');
+ 	IF "Timestamp" IS NULL THEN
+ 	  "Timestamp" := CURRENT_TIMESTAMP;
+ 	END IF;
+  ELSE
+ 	"Timestamp" := "Override";
+  END IF;
+
+  RETURN "Timestamp";
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Functions/fn_get_user_id.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Functions/fn_get_user_id.sql
@@ -1,0 +1,19 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR REPLACE FUNCTION fn_get_user_id(
+  "Override" TEXT = NULL
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE "UserId" TEXT;
+BEGIN
+  IF "Override" IS NULL THEN
+ 	"UserId" := current_setting('Session.UserId', true);
+  ELSE
+ 	"UserId" := "Override";
+  END IF;
+
+  RETURN "UserId";
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Functions/fn_get_username.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Functions/fn_get_username.sql
@@ -1,0 +1,22 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR REPLACE FUNCTION fn_get_username(
+  "Override" TEXT = NULL
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE "Username" TEXT;
+BEGIN
+  IF "Override" IS NULL THEN
+ 	"Username" := current_setting('Session.Username', true);
+    IF "Username" IS NULL THEN
+	  "Username" := current_user;
+	END IF;
+  ELSE
+ 	"Username" := "Override";
+  END IF;
+
+  RETURN "Username";
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_set_session_context.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_set_session_context.sql
@@ -1,0 +1,28 @@
+-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR REPLACE PROCEDURE sp_set_session_context(
+  "Timestamp" TIMESTAMP WITH TIME ZONE = NULL,
+  "Username" TEXT = NULL,
+  "TenantId" TEXT = NULL,
+  "UserId" TEXT = NULL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF "Timestamp" IS NOT NULL THEN
+	PERFORM set_config('Session.Timestamp', to_char("Timestamp", 'YYYY-MM-DD"T"HH24:MI:SS.FF6'), false);
+  END IF;
+  
+  IF "Username" IS NOT NULL THEN
+	PERFORM set_config('Session.Username', "Username", false);
+  END IF;
+  
+  IF "TenantId" IS NOT NULL THEN
+	PERFORM set_config('Session.TenantId', "TenantId", false);
+  END IF;
+  
+  IF "UserId" IS NOT NULL THEN
+	PERFORM set_config('Session.UserId', "UserId", false);
+  END IF;
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_authorization_exception.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_authorization_exception.sql
@@ -1,0 +1,15 @@
+-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR REPLACE PROCEDURE sp_throw_authorization_exception(
+  "message" TEXT = NULL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF "message" IS NULL THEN
+    "message" := '';
+  END IF;
+
+  RAISE USING MESSAGE = "message", ERRCODE = '56003';
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_business_exception.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_business_exception.sql
@@ -1,0 +1,15 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR REPLACE PROCEDURE sp_throw_business_exception(
+  "message" TEXT = NULL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF "message" IS NULL THEN
+    "message" := '';
+  END IF;
+
+  RAISE USING MESSAGE = "message", ERRCODE = '56002';
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_concurrency_exception.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_concurrency_exception.sql
@@ -1,0 +1,15 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR REPLACE PROCEDURE sp_throw_concurrency_exception(
+  "message" TEXT = NULL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF "message" IS NULL THEN
+    "message" := '';
+  END IF;
+
+  RAISE USING MESSAGE = "message", ERRCODE = '56004';
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_conflict_exception.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_conflict_exception.sql
@@ -1,0 +1,15 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR REPLACE PROCEDURE sp_throw_conflict_exception(
+  "message" TEXT = NULL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF "message" IS NULL THEN
+    "message" := '';
+  END IF;
+
+  RAISE USING MESSAGE = "message", ERRCODE = '56006';
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_duplicate_exception.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_duplicate_exception.sql
@@ -1,0 +1,15 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR REPLACE PROCEDURE sp_throw_duplicate_exception(
+  "message" TEXT = NULL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF "message" IS NULL THEN
+    "message" := '';
+  END IF;
+
+  RAISE USING MESSAGE = "message", ERRCODE = '56007';
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_not_found_exception.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_not_found_exception.sql
@@ -1,0 +1,15 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR REPLACE PROCEDURE sp_throw_not_found_exception(
+  "message" TEXT = NULL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF "message" IS NULL THEN
+    "message" := '';
+  END IF;
+
+  RAISE USING MESSAGE = "message", ERRCODE = '56005';
+END
+$$;

--- a/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_validation_exception.sql
+++ b/src/DbEx.Postgres/Resources/ExtendedSchema/Stored Procedures/sp_throw_validation_exception.sql
@@ -1,0 +1,15 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR REPLACE PROCEDURE sp_throw_validation_exception(
+  "message" TEXT = NULL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF "message" IS NULL THEN
+    "message" := '';
+  END IF;
+
+  RAISE USING MESSAGE = "message", ERRCODE = '56001';
+END
+$$;

--- a/src/DbEx.SqlServer/Console/MigrationArgsExtensions.cs
+++ b/src/DbEx.SqlServer/Console/MigrationArgsExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+using DbEx.Migration;
+using System;
+using System.Linq;
+
+namespace DbEx.SqlServer.Console
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="MigrationArgs"/>.
+    /// </summary>
+    public static class MigrationArgsExtensions
+    {
+        /// <summary>
+        /// Include the SQL Server extended <b>Schema</b> scripts (stored procedures and functions) from <see href="https://github.com/Avanade/DbEx/tree/main/src/DbEx.SqlServer/Resources/ExtendedSchema"/>.
+        /// </summary>
+        /// <param name="args">The <see cref="MigrationArgs"/>.</param>
+        /// <returns>The <see cref="MigrationArgs"/> to support fluent-style method-chaining.</returns>
+        public static MigrationArgs IncludeExtendedSchemaScripts(this MigrationArgs args)
+        {
+            AddExtendedSchemaScripts(args);
+            return args;
+        }
+
+        /// <summary>
+        /// Adds the SQL Server extended <b>Schema</b> scripts (stored procedures and functions) from <see href="https://github.com/Avanade/DbEx/tree/main/src/DbEx.SqlServer/Resources/ExtendedSchema"/>.
+        /// </summary>
+        /// <typeparam name="TArgs">The <see cref="MigrationArgsBase{TSelf}"/> <see cref="Type"/>.</typeparam>
+        /// <param name="args">The <see cref="MigrationArgsBase{TSelf}"/>.</param>
+        public static void AddExtendedSchemaScripts<TArgs>(TArgs args) where TArgs : MigrationArgsBase<TArgs>
+        {
+            foreach (var rn in typeof(MigrationArgsExtensions).Assembly.GetManifestResourceNames().Where(x => x.StartsWith("DbEx.SqlServer.Resources.ExtendedSchema.") && x.EndsWith(".sql")))
+            {
+                args.AddScript(MigrationCommand.Schema, typeof(MigrationArgsExtensions).Assembly, rn);
+            }
+        }
+    }
+}

--- a/src/DbEx.SqlServer/DbEx.SqlServer.csproj
+++ b/src/DbEx.SqlServer/DbEx.SqlServer.csproj
@@ -23,6 +23,18 @@
 
   <ItemGroup>
     <None Remove="Resources\DatabaseExists.sql" />
+    <None Remove="Resources\ExtendedSchema\Functions\fnGetTenantId.sql" />
+    <None Remove="Resources\ExtendedSchema\Functions\fnGetTimestamp.sql" />
+    <None Remove="Resources\ExtendedSchema\Functions\fnGetUserId.sql" />
+    <None Remove="Resources\ExtendedSchema\Functions\fnGetUsername.sql" />
+    <None Remove="Resources\ExtendedSchema\spSetSessionContext.sql" />
+    <None Remove="Resources\ExtendedSchema\spThrowAuthorizationException.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\spThrowBusinessException.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\spThrowConcurrencyException.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\spThrowConflictException.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\spThrowDuplicateException.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\spThrowNotFoundException.sql" />
+    <None Remove="Resources\ExtendedSchema\Stored Procedures\spThrowValidationException.sql" />
     <None Remove="Resources\SelectTableAlwaysGeneratedColumns.sql" />
     <None Remove="Resources\SelectTableAndColumns.sql" />
     <None Remove="Resources\SelectTableForeignKeys.sql" />
@@ -32,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.25.6" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.27.0" />
     <PackageReference Include="dbup-sqlserver" Version="5.0.41" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
   </ItemGroup>

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Functions/fnGetTenantId.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Functions/fnGetTenantId.sql
@@ -1,0 +1,21 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER FUNCTION [dbo].[fnGetTenantId]
+(
+  @Override as NVARCHAR(1024) = null
+)
+RETURNS NVARCHAR(1024)
+AS
+BEGIN
+  DECLARE @TenantId NVARCHAR(1024)
+  IF @Override IS NULL
+  BEGIN
+    SET @TenantId = CONVERT(NVARCHAR(1024), SESSION_CONTEXT(N'TenantId'));
+  END
+  ELSE
+  BEGIN
+    SET @TenantId = @Override
+  END
+  
+  RETURN @TenantId
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Functions/fnGetTimestamp.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Functions/fnGetTimestamp.sql
@@ -1,0 +1,25 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER FUNCTION [dbo].[fnGetTimestamp]
+(
+  @Override as datetime = null	
+)
+RETURNS datetime
+AS
+BEGIN
+  DECLARE @Timestamp datetime
+  IF @Override IS NULL
+  BEGIN
+    SET @Timestamp = CONVERT(datetime, SESSION_CONTEXT(N'Timestamp'));
+    IF @Timestamp IS NULL
+    BEGIN
+      SET @Timestamp = SYSUTCDATETIME()
+    END
+  END
+  ELSE
+  BEGIN
+    SET @Timestamp = @Override
+  END
+  
+  RETURN @Timestamp
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Functions/fnGetUserId.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Functions/fnGetUserId.sql
@@ -1,0 +1,21 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER FUNCTION [dbo].[fnGetUserId]
+(
+  @Override as NVARCHAR(1024) = null
+)
+RETURNS NVARCHAR(1024)
+AS
+BEGIN
+  DECLARE @UserId NVARCHAR(1024)
+  IF @Override IS NULL
+  BEGIN
+    SET @UserId = CONVERT(NVARCHAR(1024), SESSION_CONTEXT(N'UserId'));
+  END
+  ELSE
+  BEGIN
+    SET @UserId = @Override
+  END
+  
+  RETURN @UserId
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Functions/fnGetUsername.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Functions/fnGetUsername.sql
@@ -1,0 +1,25 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER FUNCTION [dbo].[fnGetUsername]
+(
+  @Override AS NVARCHAR(1024) = null
+)
+RETURNS NVARCHAR(1024)
+AS
+BEGIN
+  DECLARE @Username NVARCHAR(1024)
+  IF @Override IS NULL
+  BEGIN
+    SET @Username = CONVERT(NVARCHAR(1024), SESSION_CONTEXT(N'Username'));
+    IF @Username IS NULL
+    BEGIN
+      SET @Username = SYSTEM_USER
+    END
+  END
+  ELSE
+  BEGIN
+    SET @Username = @Override
+  END
+  
+  RETURN @Username
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spSetSessionContext.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spSetSessionContext.sql
@@ -1,0 +1,29 @@
+-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR ALTER PROCEDURE [dbo].[spSetSessionContext]
+  @Timestamp DATETIME2 = null,
+  @Username NVARCHAR(1024) = null,
+  @TenantId NVARCHAR(1024) = null,
+  @UserId NVARCHAR(1024) = null
+AS
+BEGIN
+  IF @Timestamp IS NOT NULL
+  BEGIN
+    EXEC sp_set_session_context 'Timestamp', @Timestamp, @read_only = 1;
+  END
+  
+  IF @Username IS NOT NULL
+  BEGIN
+    EXEC sp_set_session_context 'Username', @Username, @read_only = 1;
+  END
+  
+  IF @TenantId IS NOT NULL
+  BEGIN
+    EXEC sp_set_session_context 'TenantId', @TenantId, @read_only = 1;
+  END
+  
+  IF @UserId IS NOT NULL
+  BEGIN
+    EXEC sp_set_session_context 'UserId', @UserId, @read_only = 1;
+  END
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowAuthorizationException.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowAuthorizationException.sql
@@ -1,0 +1,9 @@
+-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx
+
+CREATE OR ALTER PROCEDURE [dbo].[spThrowAuthorizationException]
+  @Message NVARCHAR(2048) = NULL
+AS
+BEGIN
+  SET NOCOUNT ON;
+  THROW 56003, @Message, 1
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowBusinessException.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowBusinessException.sql
@@ -1,0 +1,9 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER PROCEDURE [dbo].[spThrowBusinessException]
+  @Message NVARCHAR(2048) = NULL
+AS
+BEGIN
+  SET NOCOUNT ON;
+  THROW 56002, @Message, 1
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowConcurrencyException.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowConcurrencyException.sql
@@ -1,0 +1,9 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER PROCEDURE [dbo].[spThrowConcurrencyException]
+  @Message NVARCHAR(2048) = NULL
+AS
+BEGIN
+  SET NOCOUNT ON;
+  THROW 56004, @Message, 1
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowConflictException.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowConflictException.sql
@@ -1,0 +1,9 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER PROCEDURE [dbo].[spThrowConflictException]
+  @Message NVARCHAR(2048) = NULL
+AS
+BEGIN
+  SET NOCOUNT ON;
+  THROW 56006, @Message, 1
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowDuplicateException.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowDuplicateException.sql
@@ -1,0 +1,9 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER PROCEDURE [dbo].[spThrowDuplicateException]
+  @Message NVARCHAR(2048) = NULL
+AS
+BEGIN
+  SET NOCOUNT ON;
+  THROW 56007, @Message, 1
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowNotFoundException.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowNotFoundException.sql
@@ -1,0 +1,9 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER PROCEDURE [dbo].[spThrowNotFoundException]
+  @Message NVARCHAR(2048) = NULL
+AS
+BEGIN
+  SET NOCOUNT ON;
+  THROW 56005, @Message, 1
+END

--- a/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowValidationException.sql
+++ b/src/DbEx.SqlServer/Resources/ExtendedSchema/Stored Procedures/spThrowValidationException.sql
@@ -1,0 +1,9 @@
+﻿-- Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+CREATE OR ALTER PROCEDURE [dbo].[spThrowValidationException]
+  @Message NVARCHAR(2048) = NULL
+AS
+BEGIN
+  SET NOCOUNT ON;
+  THROW 56001, @Message, 1
+END

--- a/src/DbEx/Console/MigrationConsoleBase.cs
+++ b/src/DbEx/Console/MigrationConsoleBase.cs
@@ -31,6 +31,7 @@ namespace DbEx.Console
         private static readonly string[] memberNames = ["args"];
         private const string EntryAssemblyOnlyOptionName = "entry-assembly-only";
         private const string AcceptPromptsOptionName = "accept-prompts";
+        private const string DropSchemaObjectsName = "drop-schema-objects";
         private CommandArgument<MigrationCommand>? _commandArg;
         private CommandArgument? _additionalArgs;
         private CommandOption? _helpOption;
@@ -126,6 +127,7 @@ namespace DbEx.Console
             ConsoleOptions.Add(nameof(MigrationArgsBase.Assemblies), app.Option("-a|--assembly", "Assembly containing embedded resources (multiple can be specified in probing order).", CommandOptionType.MultipleValue));
             ConsoleOptions.Add(nameof(MigrationArgsBase.Parameters), app.Option("-p|--param", "Parameter expressed as a 'Name=Value' pair (multiple can be specified).", CommandOptionType.MultipleValue));
             ConsoleOptions.Add(EntryAssemblyOnlyOptionName, app.Option("-eo|--entry-assembly-only", "Use the entry assembly only (ignore all other assemblies).", CommandOptionType.NoValue));
+            ConsoleOptions.Add(DropSchemaObjectsName, app.Option("-dso|--drop-schema-objects", "Drop all known schema objects before applying; bypasses automatic skip where all scripts are replacements.", CommandOptionType.NoValue));
             ConsoleOptions.Add(AcceptPromptsOptionName, app.Option("--accept-prompts", "Accept prompts; command should _not_ stop and wait for user confirmation (DROP or RESET commands).", CommandOptionType.NoValue));
             _additionalArgs = app.Argument("args", "Additional arguments; 'Script' arguments (first being the script name) -or- 'Execute' (each a SQL statement to invoke).", multipleValues: true);
 
@@ -211,6 +213,11 @@ namespace DbEx.Console
                             return new ValidationResult("Data reset was not confirmed; no execution occurred.");
                     }
                 }
+
+                // Handle drop schema objects.
+                var dso = GetCommandOption(DropSchemaObjectsName);
+                if (dso is not null && dso.HasValue())
+                    Args.DropSchemaObjects = true;
 
                 return res;
             });

--- a/src/DbEx/DatabaseSchemaConfig.cs
+++ b/src/DbEx/DatabaseSchemaConfig.cs
@@ -124,7 +124,7 @@ namespace DbEx
             Migration.Args.RefDataTextColumnName ??= RefDataTextColumnName;
 
             // Where the database has a default schema then this should be ordered first where not already set.
-            if (!string.IsNullOrEmpty(DefaultSchema) && !Migration.Args.SchemaOrder.Contains(DefaultSchema))
+            if (SupportsSchema && !string.IsNullOrEmpty(DefaultSchema) && !Migration.Args.SchemaOrder.Contains(DefaultSchema))
                 Migration.Args.SchemaOrder.Insert(0, DefaultSchema);
         }
 

--- a/src/DbEx/DatabaseSchemaConfig.cs
+++ b/src/DbEx/DatabaseSchemaConfig.cs
@@ -122,6 +122,10 @@ namespace DbEx
             Migration.Args.IsDeletedColumnName ??= IsDeletedColumnName;
             Migration.Args.RefDataCodeColumnName ??= RefDataCodeColumnName;
             Migration.Args.RefDataTextColumnName ??= RefDataTextColumnName;
+
+            // Where the database has a default schema then this should be ordered first where not already set.
+            if (!string.IsNullOrEmpty(DefaultSchema) && !Migration.Args.SchemaOrder.Contains(DefaultSchema))
+                Migration.Args.SchemaOrder.Insert(0, DefaultSchema);
         }
 
         /// <summary>

--- a/src/DbEx/DbEx.csproj
+++ b/src/DbEx/DbEx.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.25.6" />
-    <PackageReference Include="OnRamp" Version="2.2.2" />
+    <PackageReference Include="CoreEx.Database" Version="3.27.0" />
+    <PackageReference Include="OnRamp" Version="2.2.3" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/src/DbEx/Migration/MigrationArgsBaseT.cs
+++ b/src/DbEx/Migration/MigrationArgsBaseT.cs
@@ -80,5 +80,29 @@ namespace DbEx.Migration
             SchemaOrder.AddRange(schemas);
             return (TSelf)this;
         }
+
+        /// <summary>
+        /// Adds a <see cref="ExplicitMigrationScript"/> being an explicitly named resource-based script to be included (executed) as per the specified <see cref="MigrationCommand"/> (phase).
+        /// </summary>
+        /// <param name="command">The <see cref="MigrationCommand"/> (phase) where the script should be executed.</param>
+        /// <param name="assembly">The <see cref="Assembly"/> where the script resource resides.</param>
+        /// <param name="name">The corresponding resource name within the <see cref="Assembly"/>.</param>
+        /// <remarks>The <paramref name="command"/> must be a single value; currently only <see cref="MigrationCommand.Migrate"/> and <see cref="MigrationCommand.Schema"/> are supported. This represents the phase in which the script will be 
+        /// included for execution.</remarks>
+        public new TSelf AddScript(MigrationCommand command, Assembly assembly, string name)
+        {
+            base.AddScript(command, assembly, name);
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="ExplicitMigrationScript"/> being an explicitly named resource-based script to be included (executed) as per the specified <see cref="MigrationCommand"/> (phase).
+        /// </summary>
+        /// <typeparam name="TAssembly">The <see cref="Type"/> to use to infer the underlying <see cref="Type.Assembly"/> where the script resource resides.</typeparam>
+        /// <param name="command">The <see cref="MigrationCommand"/> (phase) where the script should be executed.</param>
+        /// <param name="name">The corresponding resource name within the <see cref="Assembly"/>.</param>
+        /// <remarks>The <paramref name="command"/> must be a single value; currently only <see cref="MigrationCommand.Migrate"/> and <see cref="MigrationCommand.Schema"/> are supported. This represents the phase in which the script will be 
+        /// included for execution.</remarks>
+        public TSelf AddScript<TAssembly>(MigrationCommand command, string name) => AddScript(command, typeof(TAssembly).Assembly, name);
     }
 }

--- a/tests/DbEx.Test.Console/Program.cs
+++ b/tests/DbEx.Test.Console/Program.cs
@@ -11,6 +11,7 @@ namespace DbEx.Test.Console
             {
                 c.Args.AddAssembly<DbEx.Test.OutboxConsole.Program>("Data", "Data2");
                 c.Args.AddSchemaOrder("Test", "Outbox");
+                c.Args.IncludeExtendedSchemaScripts();
                 c.Args.DataParserArgs.Parameter("DefaultName", "Bazza")
                                      .RefDataColumnDefault("SortOrder", i => i)
                                      .ColumnDefault("*", "*", "TenantId", _ => "test-tenant")

--- a/tests/DbEx.Test.Console/Resources/Table_sql.hb
+++ b/tests/DbEx.Test.Console/Resources/Table_sql.hb
@@ -1,4 +1,4 @@
-﻿{{! Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef }}
+﻿{{! Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/DbEx }}
 {{! PARAM:Param1=Schema }}
 {{! PARAM:Param2=Table }}
 {{! FILENAME:create-[lookup Parameters 'Param1']-[lookup Parameters 'Param2']-table }}

--- a/tests/DbEx.Test/DatabaseSchemaTest.cs
+++ b/tests/DbEx.Test/DatabaseSchemaTest.cs
@@ -12,6 +12,7 @@ using MySql.Data.MySqlClient;
 using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace DbEx.Test
 {

--- a/tests/DbEx.Test/DbEx.Test.csproj
+++ b/tests/DbEx.Test/DbEx.Test.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/DbEx.Test/MySqlMigrationTest.cs
+++ b/tests/DbEx.Test/MySqlMigrationTest.cs
@@ -3,6 +3,7 @@ using DbEx.MySql.Migration;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace DbEx.Test
 {

--- a/tests/DbEx.Test/PostgresMigrationTest.cs
+++ b/tests/DbEx.Test/PostgresMigrationTest.cs
@@ -1,9 +1,15 @@
-﻿using DbEx.Migration;
+﻿using CoreEx;
+using CoreEx.Database;
+using CoreEx.Database.Postgres;
+using DbEx.Migration;
+using DbEx.Postgres.Console;
 using DbEx.Postgres.Migration;
 using DbEx.Test.PostgresConsole;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
+using System;
 using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace DbEx.Test
 {
@@ -16,7 +22,7 @@ namespace DbEx.Test
         {
             var cs = UnitTest.GetConfig("DbEx_").GetConnectionString("PostgresDb");
             var l = UnitTest.GetLogger<PostgresMigrationTest>();
-            var a = new MigrationArgs(MigrationCommand.DropAndAll, cs) { Logger = l }.AddAssembly<PostgresStuff>();
+            var a = new MigrationArgs(MigrationCommand.DropAndAll, cs) { Logger = l }.AddAssembly<PostgresStuff>().IncludeExtendedSchemaScripts();
             using var m = new PostgresMigration(a);
             var r = await m.MigrateAsync().ConfigureAwait(false);
             Assert.IsTrue(r);
@@ -39,6 +45,51 @@ namespace DbEx.Test
 
             r = await m2.MigrateAsync().ConfigureAwait(false);
             Assert.IsTrue(r);
+        }
+
+        [Test]
+        public async Task B110_Throw_Exceptions()
+        {
+            await A120_MigrateAll();
+
+            var cs = UnitTest.GetConfig("DbEx_").GetConnectionString("PostgresDb");
+            using var db = new PostgresDatabase(() => new Npgsql.NpgsqlConnection(cs));
+
+            Assert.ThrowsAsync<AuthorizationException>(() => db.StoredProcedure("sp_throw_authorization_exception").Param("message", null).NonQueryAsync());
+            Assert.ThrowsAsync<BusinessException>(() => db.StoredProcedure("sp_throw_business_exception").Param("message", null).NonQueryAsync());
+            Assert.ThrowsAsync<ConcurrencyException>(() => db.StoredProcedure("sp_throw_concurrency_exception").Param("message", null).NonQueryAsync());
+            Assert.ThrowsAsync<ConflictException>(() => db.StoredProcedure("sp_throw_conflict_exception").Param("message", null).NonQueryAsync());
+            Assert.ThrowsAsync<DuplicateException>(() => db.StoredProcedure("sp_throw_duplicate_exception").Param("message", null).NonQueryAsync());
+            Assert.ThrowsAsync<NotFoundException>(() => db.StoredProcedure("sp_throw_not_found_exception").Param("message", null).NonQueryAsync());
+            Assert.ThrowsAsync<ValidationException>(() => db.StoredProcedure("sp_throw_validation_exception").Param("message", null).NonQueryAsync());
+            var vex = Assert.ThrowsAsync<ValidationException>(() => db.StoredProcedure("sp_throw_validation_exception").Param("message", "On no!").NonQueryAsync());
+            Assert.AreEqual("On no!", vex.Message);
+        }
+
+        [Test]
+        public async Task B120_Set_Session_Context()
+        {
+            await A120_MigrateAll();
+
+            var cs = UnitTest.GetConfig("DbEx_").GetConnectionString("PostgresDb");
+            using var db = new PostgresDatabase(() => new Npgsql.NpgsqlConnection(cs));
+
+            var now = DateTime.UtcNow;
+            var ts = new DateTime(2024, 09, 30, 23, 45, 08, 123, DateTimeKind.Utc);
+
+            await db.SetPostgresSessionContextAsync("bob@gmail.com", ts, "banana", "bob2");
+
+            Assert.That(await db.SqlStatement("select fn_get_timestamp()").ScalarAsync<DateTime>(), Is.EqualTo(ts));
+            Assert.That(await db.SqlStatement("select fn_get_username()").ScalarAsync<string>(), Is.EqualTo("bob@gmail.com"));
+            Assert.That(await db.SqlStatement("select fn_get_tenant_id()").ScalarAsync<string>(), Is.EqualTo("banana"));
+            Assert.That(await db.SqlStatement("select fn_get_user_id()").ScalarAsync<string>(), Is.EqualTo("bob2"));
+
+            // Make sure the session context doesn't leak between connections.
+            using var db2 = new PostgresDatabase(() => new Npgsql.NpgsqlConnection(cs));
+            Assert.That(await db2.SqlStatement("select fn_get_timestamp()").ScalarAsync<DateTime>(), Is.GreaterThanOrEqualTo(now));
+            Assert.That(await db2.SqlStatement("select fn_get_username()").ScalarAsync<string>(), Is.Not.Null.And.Not.EqualTo("bob@gmail.com"));
+            Assert.That(await db2.SqlStatement("select fn_get_tenant_id()").ScalarAsync<string>(), Is.Null);
+            Assert.That(await db2.SqlStatement("select fn_get_user_id()").ScalarAsync<string>(), Is.Null);
         }
     }
 }

--- a/tests/DbEx.Test/SqlServerOutboxTest.cs
+++ b/tests/DbEx.Test/SqlServerOutboxTest.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace DbEx.Test
 {


### PR DESCRIPTION
- *Enhancement:* Require a means to add an explicitly named resource-based script outside of the automatic convention-based discovery; see new `MigrationArgs.AddScript`.
- *Enhancement:* Moving the [_Beef_](https://github.com/Avanade/beef)-based standardized SQL Server scripts (functions and stored procedures) to _DbEx_ to enable greater usage. New `MigrationArgs.IncludeExtendedSchemaScripts` extension method will add (leverages new `MigrationArgs.AddScript`).
- *Enhancement:* Added PostgreSQL equivalent standardized SQL Server scripts (functions and stored procedures).
- *Enhancement:* Added command-line option `-dso|--drop-schema-objects` to set `MigrationArgs.DropSchemaObjects` directly from the console.