### PR TITLE
Fix incorrect index increment in SQL Server schema script parser

### DIFF
--- a/src/DbEx.SqlServer/Migration/SqlServerSchemaScript.cs
+++ b/src/DbEx.SqlServer/Migration/SqlServerSchemaScript.cs
@@ -36,7 +36,7 @@ namespace DbEx.SqlServer.Migration
                 {
                     if (string.Compare(tokens[i + 1], "or", StringComparison.OrdinalIgnoreCase) == 0 && string.Compare(tokens[i + 2], "alter", StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        i = +2;
+                        i += 2;
                         script.SupportsReplace = true;
                     }
 


### PR DESCRIPTION
## Bug Description

The SQL Server schema script parser had a logic error where `i = +2` was used instead of `i += 2` when detecting 'OR ALTER' tokens in CREATE statements.

## Impact

This caused the parser to incorrectly set the index to `2` instead of adding `2` to the current index, resulting in incorrect token parsing for statements like:

```sql
CREATE OR ALTER TABLE dbo.MyTable (...)
```

## Fix

Changed the assignment operator from `=` to `+=` to properly increment the index by 2, skipping past the 'OR ALTER' tokens.

## Testing

The fix ensures that when parsing `CREATE OR ALTER TYPE/VIEW/PROCEDURE` statements, the parser correctly advances past the 'OR ALTER' tokens and properly extracts the object type and fully qualified name.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.