### PR TITLE
v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Represents the **NuGet** versions.
 
 ## v3.1.0
 - *Enhancement:* Added new `MigrationCommand.Inspect` to inspect the specified database tables and outputs schema-based markdown to the console. 
-  - This is intended to be a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
+  - This is intended to be a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, default values, and primary key, identity, computed and unique status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
   - Command line execution is as: `dotnet run -- inspect schema table1 table2`
 
 ## v3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v3.1.0
+- *Enhancement:* Added new `MigrationCommand.Inspect` to inspect the specified database tables and outputs schema-based markdown to the console. 
+  - This is intended to be a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
+  - Command line execution is as: `dotnet run -- inspect schema table1 table2`
+
 ## v3.0.2
 - *Fixed:* The SQL Server outbox stored procedures, where applicable, have had redundant, dead code, removed.
 - *Fixed:* Add name of entry assembly to the generated code file header comments to provide better visibility of generation source process.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.2</Version>
+    <Version>3.1.0</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ dotnet run execute ./schema/createscehma.sql
 
 #### Inspect command
 
-The `Inspect` command provides a quick-and-easy way to inspect the inferred schema of one or more existing database tables. The output is a basic markdown document - written to the console - that includes whether each table exists, whether it is a view, whether it is treated as reference data, and a per-column table listing the column name, data type, nullability, default value, primary key, identity and computed flags. The markdown can be copied directly into any markdown viewer or editor for further use.
+The `Inspect` command provides a quick-and-easy way to inspect the inferred schema of one or more existing database tables. The output is a basic markdown document - written to the console - that includes whether each table exists, whether it is a view, whether it is treated as reference data, and a per-column table listing the column name, data type, nullability, default value, primary key, identity, computed and unique flags. The markdown can be copied directly into any markdown viewer or editor for further use.
 
 The arguments are the schema name (where supported by the database provider) followed by one or more table names. For database providers that do not use schemas (for example MySQL) only the table names are required.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Command | Description
 `ResetAndDatabase` | Performs `Reset` and `Database` (designed primarily for testing).
 `Execute` | Executes the SQL statement(s) passed as additional arguments.
 `Script` | Creates a new [`migration`](#Migrate) script file using the defined naming convention.
-[`Inspect`](#Inspect) | Inspects one or more existing database tables and outputs the inferred schema (columns, types, nullability, defaults, primary key, identity and computed flags) as markdown to the console.
+[`Inspect`](#Inspect) | Inspects one or more existing database tables and outputs the inferred schema (columns, types, nullability, defaults, primary key, identity, computed and unique flags) as markdown to the console.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Command | Description
 `ResetAndDatabase` | Performs `Reset` and `Database` (designed primarily for testing).
 `Execute` | Executes the SQL statement(s) passed as additional arguments.
 `Script` | Creates a new [`migration`](#Migrate) script file using the defined naming convention.
+[`Inspect`](#Inspect) | Inspects one or more existing database tables and outputs the inferred schema (columns, types, nullability, defaults, primary key, identity and computed flags) as markdown to the console.
 
 <br/>
 
@@ -208,8 +209,8 @@ Usage: Xxx [options] <command> <args>
 Arguments:
   command                    Database migration command (see https://github.com/Avanade/dbex#commands-functions).
                              Allowed values are: None, Drop, Create, Migrate, CodeGen, Schema, Deploy, Reset, Data, DeployWithData, Database, DropAndDatabase, All, DropAndAll,
-                             ResetAndData, ResetAndDatabase, ResetAndAll, Execute, Script.
-  args                       Additional arguments; 'Script' arguments (first being the script name) -or- 'Execute' (each a SQL statement to invoke).
+                             ResetAndData, ResetAndDatabase, ResetAndAll, Execute, Script, Inspect.
+  args                       Additional arguments; 'Script' arguments (first being the script name) -or- 'Execute' (each a SQL statement to invoke) -or- 'Inspect' (schema followed by one or more table names).
 
 Options:
   -?|-h|--help               Show help information.
@@ -291,6 +292,21 @@ Examples as follows.
 ```
 dotnet run execute "create schema [Xyz] authorization [dbo]"
 dotnet run execute ./schema/createscehma.sql
+```
+
+<br/>
+
+#### Inspect command
+
+The `Inspect` command provides a quick-and-easy way to inspect the inferred schema of one or more existing database tables. The output is a basic markdown document - written to the console - that includes whether each table exists, whether it is a view, whether it is treated as reference data, and a per-column table listing the column name, data type, nullability, default value, primary key, identity and computed flags. The markdown can be copied directly into any markdown viewer or editor for further use.
+
+The arguments are the schema name (where supported by the database provider) followed by one or more table names. For database providers that do not use schemas (for example MySQL) only the table names are required.
+
+Examples as follows.
+
+```
+dotnet run inspect dbo Person
+dotnet run inspect Demo Person WorkHistory
 ```
 
 <br/>

--- a/src/DbEx.MySql/Console/MySqlMigrationConsole.cs
+++ b/src/DbEx.MySql/Console/MySqlMigrationConsole.cs
@@ -49,10 +49,13 @@ public sealed class MySqlMigrationConsole : MigrationConsoleBase<MySqlMigrationC
     /// </summary>
     public void WriteScriptHelp()
     {
+        Logger?.LogInformation("{help}", "Inspect command and argument(s):");
+        Logger?.LogInformation("{help}", "  inspect <table1> <table2>...  Inspects one or more database tables.");
+        Logger?.LogInformation("{help}", string.Empty);
         Logger?.LogInformation("{help}", "Script command and argument(s):");
-        Logger?.LogInformation("{help}", "  script [default]         Creates a default (empty) SQL script.");
-        Logger?.LogInformation("{help}", "  script alter <table>     Creates a SQL script to perform an ALTER TABLE.");
-        Logger?.LogInformation("{help}", "  script create <table>    Creates a SQL script to perform a CREATE TABLE.");
-        Logger?.LogInformation("{help}", "  script refdata <table>   Creates a SQL script to perform a CREATE TABLE as reference data.");
+        Logger?.LogInformation("{help}", "  script [default]              Creates a default (empty) SQL script.");
+        Logger?.LogInformation("{help}", "  script alter <table>          Creates a SQL script to perform an ALTER TABLE.");
+        Logger?.LogInformation("{help}", "  script create <table>         Creates a SQL script to perform a CREATE TABLE.");
+        Logger?.LogInformation("{help}", "  script refdata <table>        Creates a SQL script to perform a CREATE TABLE as reference data.");
     }
 }

--- a/src/DbEx.Postgres/Console/PostgresMigrationConsole.cs
+++ b/src/DbEx.Postgres/Console/PostgresMigrationConsole.cs
@@ -49,12 +49,15 @@ public sealed class PostgresMigrationConsole : MigrationConsoleBase<PostgresMigr
     /// </summary>
     public void WriteScriptHelp()
     {
+        Logger?.LogInformation("{help}", "Inspect command and argument(s):");
+        Logger?.LogInformation("{help}", "  inspect <schema> <table1> <table2>...  Inspects one or more database tables within the specified schema.");
+        Logger?.LogInformation("{help}", string.Empty);
         Logger?.LogInformation("{help}", "Script command and argument(s):");
-        Logger?.LogInformation("{help}", "  script [default]                  Creates a default (empty) SQL script.");
-        Logger?.LogInformation("{help}", "  script alter <schema> <table>     Creates a SQL script to perform an ALTER TABLE.");
-        Logger?.LogInformation("{help}", "  script create <schema> <table>    Creates a SQL script to perform a CREATE TABLE.");
-        Logger?.LogInformation("{help}", "  script outbox <Schema> <Table>    Creates a SQL script to perform a CREATE TABLE(s) for an Outbox.");
-        Logger?.LogInformation("{help}", "  script refdata <schema> <table>   Creates a SQL script to perform a CREATE TABLE as reference data.");
-        Logger?.LogInformation("{help}", "  script schema <schema>            Creates a SQL script to perform a CREATE SCHEMA.");
+        Logger?.LogInformation("{help}", "  script [default]                       Creates a default (empty) SQL script.");
+        Logger?.LogInformation("{help}", "  script alter <schema> <table>          Creates a SQL script to perform an ALTER TABLE.");
+        Logger?.LogInformation("{help}", "  script create <schema> <table>         Creates a SQL script to perform a CREATE TABLE.");
+        Logger?.LogInformation("{help}", "  script outbox <Schema> <Table>         Creates a SQL script to perform a CREATE TABLE(s) for an Outbox.");
+        Logger?.LogInformation("{help}", "  script refdata <schema> <table>        Creates a SQL script to perform a CREATE TABLE as reference data.");
+        Logger?.LogInformation("{help}", "  script schema <schema>                 Creates a SQL script to perform a CREATE SCHEMA.");
     }
 }

--- a/src/DbEx.SqlServer/Console/SqlServerMigrationConsole.cs
+++ b/src/DbEx.SqlServer/Console/SqlServerMigrationConsole.cs
@@ -48,15 +48,18 @@ public sealed class SqlServerMigrationConsole : MigrationConsoleBase<SqlServerMi
     /// Writes the supported <see cref="MigrationCommand.Script"/> help content.
     /// </summary>
     public void WriteScriptHelp()
-    { 
+    {
+        Logger?.LogInformation("{help}", "Inspect command and argument(s):");
+        Logger?.LogInformation("{help}", "  inspect <schema> <table1> <table2>...  Inspects one or more database tables within the specified schema.");
+        Logger?.LogInformation("{help}", string.Empty);
         Logger?.LogInformation("{help}", "Script command and argument(s):");
-        Logger?.LogInformation("{help}", "  script [default]                  Creates a default (empty) SQL script.");
-        Logger?.LogInformation("{help}", "  script alter <Schema> <Table>     Creates a SQL script to perform an ALTER TABLE.");
-        Logger?.LogInformation("{help}", "  script cdc <Schema> <Table>       Creates a SQL script to turn on CDC for the specified table.");
-        Logger?.LogInformation("{help}", "  script cdcdb                      Creates a SQL script to turn on CDC for the database.");
-        Logger?.LogInformation("{help}", "  script create <Schema> <Table>    Creates a SQL script to perform a CREATE TABLE.");
-        Logger?.LogInformation("{help}", "  script outbox <Schema> <Table>    Creates a SQL script to perform a CREATE TABLE(s) for an Outbox.");
-        Logger?.LogInformation("{help}", "  script refdata <Schema> <Table>   Creates a SQL script to perform a CREATE TABLE as reference data.");
-        Logger?.LogInformation("{help}", "  script schema <Schema>            Creates a SQL script to perform a CREATE SCHEMA.");
+        Logger?.LogInformation("{help}", "  script [default]                       Creates a default (empty) SQL script.");
+        Logger?.LogInformation("{help}", "  script alter <Schema> <Table>          Creates a SQL script to perform an ALTER TABLE.");
+        Logger?.LogInformation("{help}", "  script cdc <Schema> <Table>            Creates a SQL script to turn on CDC for the specified table.");
+        Logger?.LogInformation("{help}", "  script cdcdb                           Creates a SQL script to turn on CDC for the database.");
+        Logger?.LogInformation("{help}", "  script create <Schema> <Table>         Creates a SQL script to perform a CREATE TABLE.");
+        Logger?.LogInformation("{help}", "  script outbox <Schema> <Table>         Creates a SQL script to perform a CREATE TABLE(s) for an Outbox.");
+        Logger?.LogInformation("{help}", "  script refdata <Schema> <Table>        Creates a SQL script to perform a CREATE TABLE as reference data.");
+        Logger?.LogInformation("{help}", "  script schema <Schema>                 Creates a SQL script to perform a CREATE SCHEMA.");
     }
 }

--- a/src/DbEx/Console/MigrationConsoleBase.cs
+++ b/src/DbEx/Console/MigrationConsoleBase.cs
@@ -62,8 +62,8 @@ public abstract class MigrationConsoleBase(MigrationArgsBase args)
     /// <summary>
     /// Gets or sets the supported <see cref="MigrationCommand"/>(s); where executed with an unsupported command an error will occur.
     /// </summary>
-    /// <remarks>Defaults to everything: <see cref="MigrationCommand.All"/>, <see cref="MigrationCommand.Reset"/>, <see cref="MigrationCommand.Drop"/>, <see cref="MigrationCommand.Execute"/> and <see cref="MigrationCommand.Script"/>.</remarks>
-    public MigrationCommand SupportedCommands { get; set; } = MigrationCommand.All | MigrationCommand.Reset | MigrationCommand.Drop | MigrationCommand.Execute | MigrationCommand.Script;
+    /// <remarks>Defaults to everything: <see cref="MigrationCommand.All"/>, <see cref="MigrationCommand.Reset"/>, <see cref="MigrationCommand.Drop"/>, <see cref="MigrationCommand.Execute"/>, <see cref="MigrationCommand.Script"/> and <see cref="MigrationCommand.Inspect"/>.</remarks>
+    public MigrationCommand SupportedCommands { get; set; } = MigrationCommand.All | MigrationCommand.Reset | MigrationCommand.Drop | MigrationCommand.Execute | MigrationCommand.Script | MigrationCommand.Inspect;
 
     /// <summary>
     /// Runs the code generation using the passed <paramref name="migrationCommand"/>.
@@ -142,10 +142,10 @@ public abstract class MigrationConsoleBase(MigrationArgsBase args)
             if (vr != ValidationResult.Success)
                 return vr;
 
-            if (_additionalArgs.Values.Count > 0 && !(Args.MigrationCommand.HasFlag(MigrationCommand.CodeGen) || Args.MigrationCommand.HasFlag(MigrationCommand.Script) || Args.MigrationCommand.HasFlag(MigrationCommand.Execute)))
-                return new ValidationResult($"Additional arguments can only be specified when the command is '{nameof(MigrationCommand.CodeGen)}', '{nameof(MigrationCommand.Script)}' or '{nameof(MigrationCommand.Execute)}'.", memberNames);
+            if (_additionalArgs.Values.Count > 0 && !(Args.MigrationCommand.HasFlag(MigrationCommand.CodeGen) || Args.MigrationCommand.HasFlag(MigrationCommand.Script) || Args.MigrationCommand.HasFlag(MigrationCommand.Execute) || Args.MigrationCommand.HasFlag(MigrationCommand.Inspect)))
+                return new ValidationResult($"Additional arguments can only be specified when the command is '{nameof(MigrationCommand.CodeGen)}', '{nameof(MigrationCommand.Script)}', '{nameof(MigrationCommand.Execute)}' or '{nameof(MigrationCommand.Inspect)}'.", memberNames);
 
-            if (Args.MigrationCommand.HasFlag(MigrationCommand.CodeGen) || Args.MigrationCommand.HasFlag(MigrationCommand.Script))
+            if (Args.MigrationCommand.HasFlag(MigrationCommand.CodeGen) || Args.MigrationCommand.HasFlag(MigrationCommand.Script) || Args.MigrationCommand.HasFlag(MigrationCommand.Inspect))
             {
                 for (int i = 0; i < _additionalArgs.Values.Count; i++)
                 {
@@ -301,7 +301,7 @@ public abstract class MigrationConsoleBase(MigrationArgsBase args)
             using var migrator = CreateMigrator();
 
             // Write header, etc.
-            if (!BypassOnWrites)
+            if (!BypassOnWrites && !migrator.Args.MigrationCommand.HasFlag(MigrationCommand.Inspect))
             {
                 OnWriteMasthead();
                 OnWriteHeader();
@@ -315,7 +315,7 @@ public abstract class MigrationConsoleBase(MigrationArgsBase args)
 
             // Write footer and exit successfully.
             sw.Stop();
-            if (!BypassOnWrites)
+            if (!BypassOnWrites && !migrator.Args.MigrationCommand.HasFlag(MigrationCommand.Inspect))
                 OnWriteFooter(sw.Elapsed.TotalMilliseconds);
 
             return 0;
@@ -347,8 +347,11 @@ public abstract class MigrationConsoleBase(MigrationArgsBase args)
         if (!await migrator.MigrateAsync(cancellationToken).ConfigureAwait(false))
             return false;
 
-        Logger?.LogInformation("{Content}", string.Empty);
-        Logger?.LogInformation("{Content}", new string('-', 80));
+        if (!migrator.Args.MigrationCommand.HasFlag(MigrationCommand.Inspect))
+        {
+            Logger?.LogInformation("{Content}", string.Empty);
+            Logger?.LogInformation("{Content}", new string('-', 80));
+        }
 
         return true;
     }

--- a/src/DbEx/DbSchema/DbColumnSchema.cs
+++ b/src/DbEx/DbSchema/DbColumnSchema.cs
@@ -1,4 +1,4 @@
-﻿        namespace DbEx.DbSchema;
+﻿namespace DbEx.DbSchema;
 
 /// <summary>
 /// Represents the Database <b>Column</b> schema definition.

--- a/src/DbEx/DbSchema/DbColumnSchema.cs
+++ b/src/DbEx/DbSchema/DbColumnSchema.cs
@@ -1,4 +1,4 @@
-﻿namespace DbEx.DbSchema;
+﻿        namespace DbEx.DbSchema;
 
 /// <summary>
 /// Represents the Database <b>Column</b> schema definition.

--- a/src/DbEx/Migration/DatabaseMigrationBase.cs
+++ b/src/DbEx/Migration/DatabaseMigrationBase.cs
@@ -166,6 +166,9 @@ public abstract class DatabaseMigrationBase : IDisposable
         if (Args.MigrationCommand.HasFlag(MigrationCommand.Execute))
             return await ExecuteSqlStatementsAsync(Args.ExecuteStatements?.ToArray() ?? [], cancellationToken).ConfigureAwait(false);
 
+        if (Args.MigrationCommand.HasFlag(MigrationCommand.Inspect))
+            return await InspectAsync(Args.CreateStringParameters(), cancellationToken).ConfigureAwait(false);
+
         /* The remaining commands are executed in sequence as defined (where selected) to enable multiple in the correct run order. */
 
         // Database drop.
@@ -1040,6 +1043,102 @@ public abstract class DatabaseMigrationBase : IDisposable
         }
 
         return await ExecuteScriptsAsync(scripts, false, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Inspects the database table and outputs schema-based markdown to the console.
+    /// </summary>
+    /// <param name="parameters">The optional parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    /// <returns><c>true</c> indicates success; otherwise, <c>false</c>.</returns>
+    public async Task<bool> InspectAsync(IDictionary<string, string?>? parameters = null, CancellationToken cancellationToken = default)
+    {
+        Logger.LogInformation("{Content}", $"# DATABASE INSPECT (provider: {Provider})");
+        Logger.LogInformation("{Content}", string.Empty);
+        Logger.LogInformation("{Content}", "This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.");
+        Logger.LogInformation("{Content}", string.Empty);
+        Logger.LogInformation("{Content}", "**Note**: This following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.");
+        Logger.LogInformation("{Content}", string.Empty);
+
+        if (parameters is null || parameters.Count == 0)
+            return true;
+
+        // Extract the schema and table names from the parameters.
+        string? schema = null;
+        string[] names = [];
+        if (SchemaConfig.SupportsSchema)
+        {
+            if (parameters?.TryGetValue("Param0", out schema) ?? false)
+                names = [.. parameters.Where(x => x.Key.StartsWith("Param") && x.Key != "Param0" && !string.IsNullOrEmpty(x.Value)).Select(x => x.Value!)];
+
+            if (string.IsNullOrEmpty(schema))
+                return true;
+        }
+        else
+            names = [.. parameters.Where(x => x.Key.StartsWith("Param") && x.Key != "Param0" && !string.IsNullOrEmpty(x.Value)).Select(x => x.Value!)];
+
+        if (names.Length == 0) return true;
+
+        // Query the database schema and find the matching tables to output the markdown for.
+        var dbTables = await Database.SelectSchemaAsync(this, cancellationToken).ConfigureAwait(false);
+        foreach (string name in names)
+        {
+            var table = dbTables.Where(x => (schema == null || string.Compare(x.Schema, schema, StringComparison.OrdinalIgnoreCase) == 0) && string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            InspectTableMarkdown(schema, name, table);
+        }
+
+        return true;
+    }
+
+    private void InspectTableMarkdown(string? schema, string name, DbSchema.DbTableSchema? table)
+    {
+        Logger.LogInformation("{Content}", $"## {(string.IsNullOrEmpty(schema) ? "" : $"{schema.ToUpperInvariant()}.")}{name.ToUpperInvariant()} - Exists: {(table != null ? "Yes" : "No")}");
+        Logger.LogInformation("{Content}", string.Empty);
+
+        if (table is null) return;
+
+        Logger.LogInformation("{Content}", $"- Schema: {table.Schema ?? "n/a"}");
+        Logger.LogInformation("{Content}", $"- Name: {table.Name}");
+        Logger.LogInformation("{Content}", $"- Qualified Name: {SchemaConfig.ToFullyQualifiedTableName(table.Schema, table.Name)}");
+        Logger.LogInformation("{Content}", $"- Table or View: {(table.IsAView ? "View" : "Table")}");
+        Logger.LogInformation("{Content}", $"- Reference Data: {(table.IsRefData ? "Yes" : "No")}");
+        Logger.LogInformation("{Content}", string.Empty);
+        Logger.LogInformation("{Content}", "### Columns");
+        Logger.LogInformation("{Content}", string.Empty);
+        
+        var columns = new List<List<string>>();
+        foreach (var c in table?.Columns ?? [])
+        {
+            columns.Add(
+            [
+                c.Name,
+                c.SqlType2,
+                c.IsNullable ? "Yes" : "No",
+                c.DefaultValue ?? string.Empty,
+                c.IsPrimaryKey ? "Yes" : "No",
+                c.IsIdentity ? "Yes" : "No",
+                c.IsComputed ? "Yes" : "No",
+                c.IsUnique ? "Yes" : "No"
+            ]);
+        }
+
+        var columnMaxLength = Math.Max("Column".Length, columns.Max(x => x[0].Length));
+        var typeMaxLength = Math.Max("Type".Length, columns.Max(x => x[1].Length));
+        var isNullMaxLength = Math.Max("Null".Length, columns.Max(x => x[2].Length));
+        var defaultMaxLength = Math.Max("Default".Length, columns.Max(x => x[3].Length));
+        var pkMaxLength = Math.Max("PK".Length, columns.Max(x => x[4].Length));
+        var identityMaxLength = Math.Max("Identity".Length, columns.Max(x => x[5].Length));
+        var computedMaxLength = Math.Max("Computed".Length, columns.Max(x => x[6].Length));
+        var uniqueMaxLength = Math.Max("Unique".Length, columns.Max(x => x[7].Length));
+
+        Logger.LogInformation("{Content}", $"| Column{new string(' ', columnMaxLength - "Column".Length)} | Type{new string(' ', typeMaxLength - "Type".Length)} | Null{new string(' ', isNullMaxLength - "Null".Length)} | Default{new string(' ', defaultMaxLength - "Default".Length)} | PK{new string(' ', pkMaxLength - "PK".Length)} | Identity{new string(' ', identityMaxLength - "Identity".Length)} | Computed{new string(' ', computedMaxLength - "Computed".Length)} | Unique{new string(' ', uniqueMaxLength - "Unique".Length)} |");
+        Logger.LogInformation("{Content}", $"|-{"".PadRight(columnMaxLength, '-')}-|-{"".PadRight(typeMaxLength, '-')}-|-{"".PadRight(isNullMaxLength, '-')}-|-{"".PadRight(defaultMaxLength, '-')}-|-{"".PadRight(pkMaxLength, '-')}-|-{"".PadRight(identityMaxLength, '-')}-|-{"".PadRight(computedMaxLength, '-')}-|-{"".PadRight(uniqueMaxLength, '-')}-|");
+        foreach (var column in columns)
+        {
+            Logger.LogInformation("{Content}", $"| {column[0].PadRight(columnMaxLength)} | {column[1].PadRight(typeMaxLength)} | {column[2].PadRight(isNullMaxLength)} | {column[3].PadRight(defaultMaxLength)} | {column[4].PadRight(pkMaxLength)} | {column[5].PadRight(identityMaxLength)} | {column[6].PadRight(computedMaxLength)} | {column[7].PadRight(uniqueMaxLength)} |");
+        }
+
+        Logger.LogInformation("{Content}", string.Empty);
     }
 
     /// <summary>

--- a/src/DbEx/Migration/DatabaseMigrationBase.cs
+++ b/src/DbEx/Migration/DatabaseMigrationBase.cs
@@ -1057,7 +1057,7 @@ public abstract class DatabaseMigrationBase : IDisposable
         Logger.LogInformation("{Content}", string.Empty);
         Logger.LogInformation("{Content}", "This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.");
         Logger.LogInformation("{Content}", string.Empty);
-        Logger.LogInformation("{Content}", "**Note**: This following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.");
+        Logger.LogInformation("{Content}", "**Note**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.");
         Logger.LogInformation("{Content}", string.Empty);
 
         if (parameters is null || parameters.Count == 0)
@@ -1075,7 +1075,7 @@ public abstract class DatabaseMigrationBase : IDisposable
                 return true;
         }
         else
-            names = [.. parameters.Where(x => x.Key.StartsWith("Param") && x.Key != "Param0" && !string.IsNullOrEmpty(x.Value)).Select(x => x.Value!)];
+            names = [.. parameters.Where(x => x.Key.StartsWith("Param") && !string.IsNullOrEmpty(x.Value)).Select(x => x.Value!)];
 
         if (names.Length == 0) return true;
 

--- a/src/DbEx/MigrationCommand.cs
+++ b/src/DbEx/MigrationCommand.cs
@@ -110,5 +110,11 @@ public enum MigrationCommand
     /// Creates a new <see cref="Migrate">migration</see> script file using the defined naming convention.
     /// </summary>
     /// <remarks>This can not be used with any of the other commands.</remarks>
-    Script = 2048
+    Script = 2048,
+
+    /// <summary>
+    /// Inspects the specified database tables and outputs schema-based markdown to the console. 
+    /// </summary>
+    /// <remarks>This is intended for development and testing purposes only.</remarks>
+    Inspect = 4096
 }

--- a/tests/DbEx.Test.Console/Properties/launchSettings.json
+++ b/tests/DbEx.Test.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DbEx.Test.Console": {
       "commandName": "Project",
-      "commandLineArgs": "all"
+      "commandLineArgs": "inspect test gender contact"
     }
   }
 }

--- a/tests/DbEx.Test/DbEx.Test.csproj
+++ b/tests/DbEx.Test/DbEx.Test.csproj
@@ -10,6 +10,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Resources\SqlServerInspect.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\MySqlInspect.md" />
+    <EmbeddedResource Include="Resources\PostgresInspect.md" />
+    <EmbeddedResource Include="Resources\SqlServerInspect.md" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />

--- a/tests/DbEx.Test/MySqlMigrationTest.cs
+++ b/tests/DbEx.Test/MySqlMigrationTest.cs
@@ -48,10 +48,9 @@ namespace DbEx.Test
             var cs = UnitTest.GetConfig("DbEx_").GetConnectionString("MySqlDb");
             var l = UnitTest.GetLogger<MySqlMigrationTest>();
             var a = new MigrationArgs(MigrationCommand.Inspect, cs) { Logger = l };
-            a.Parameters.Add("Param0", "public");
-            a.Parameters.Add("Param1", "unknown");
-            a.Parameters.Add("Param2", "gender");
-            a.Parameters.Add("Param3", "CONTACT");
+            a.Parameters.Add("Param0", "unknown");
+            a.Parameters.Add("Param1", "gender");
+            a.Parameters.Add("Param2", "CONTACT");
 
             using var m = new MySqlMigration(a);
             var (Success, Output) = await m.MigrateAndLogAsync().ConfigureAwait(false);

--- a/tests/DbEx.Test/MySqlMigrationTest.cs
+++ b/tests/DbEx.Test/MySqlMigrationTest.cs
@@ -1,5 +1,6 @@
 ﻿using DbEx.Migration;
 using DbEx.MySql.Migration;
+using DbEx.Postgres.Migration;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 using System.Threading.Tasks;
@@ -39,6 +40,27 @@ namespace DbEx.Test
 
             r = await m2.MigrateAsync().ConfigureAwait(false);
             Assert.IsTrue(r);
+        }
+
+        [Test]
+        public async Task MySqlInspect()
+        {
+            var cs = UnitTest.GetConfig("DbEx_").GetConnectionString("MySqlDb");
+            var l = UnitTest.GetLogger<MySqlMigrationTest>();
+            var a = new MigrationArgs(MigrationCommand.Inspect, cs) { Logger = l };
+            a.Parameters.Add("Param0", "public");
+            a.Parameters.Add("Param1", "unknown");
+            a.Parameters.Add("Param2", "gender");
+            a.Parameters.Add("Param3", "CONTACT");
+
+            using var m = new MySqlMigration(a);
+            var (Success, Output) = await m.MigrateAndLogAsync().ConfigureAwait(false);
+
+            Assert.IsTrue(Success);
+            Assert.IsTrue(Output.Length > 0);
+
+            using var sr = MySqlMigration.GetRequiredResourcesStreamReader("MySqlInspect.md", [typeof(MySqlMigrationTest).Assembly]);
+            Assert.AreEqual(sr.ReadToEnd(), Output);
         }
     }
 }

--- a/tests/DbEx.Test/PostgresMigrationTest.cs
+++ b/tests/DbEx.Test/PostgresMigrationTest.cs
@@ -1,6 +1,7 @@
 ﻿using DbEx.Migration;
 using DbEx.Postgres.Console;
 using DbEx.Postgres.Migration;
+using DbEx.SqlServer.Migration;
 using DbEx.Test.PostgresConsole;
 using Microsoft.Extensions.Configuration;
 using Npgsql;
@@ -96,6 +97,27 @@ namespace DbEx.Test
             Assert.That(await db2.SqlStatement("select fn_get_username()").ScalarAsync<string>(), Is.Not.Null.And.Not.EqualTo("bob@gmail.com"));
             Assert.That(await db2.SqlStatement("select fn_get_tenant_id()").ScalarAsync<string>(), Is.Null);
             Assert.That(await db2.SqlStatement("select fn_get_user_id()").ScalarAsync<string>(), Is.Null);
+        }
+
+        [Test]
+        public async Task PostgresInspect()
+        {
+            var cs = UnitTest.GetConfig("DbEx_").GetConnectionString("PostgresDb");
+            var l = UnitTest.GetLogger<PostgresMigrationTest>();
+            var a = new MigrationArgs(MigrationCommand.Inspect, cs) { Logger = l };
+            a.Parameters.Add("Param0", "public");
+            a.Parameters.Add("Param1", "unknown");
+            a.Parameters.Add("Param2", "gender");
+            a.Parameters.Add("Param3", "CONTACT");
+
+            using var m = new PostgresMigration(a);
+            var (Success, Output) = await m.MigrateAndLogAsync().ConfigureAwait(false);
+
+            Assert.IsTrue(Success);
+            Assert.IsTrue(Output.Length > 0);
+
+            using var sr = PostgresMigration.GetRequiredResourcesStreamReader("PostgresInspect.md", [typeof(PostgresMigrationTest).Assembly]);
+            Assert.AreEqual(sr.ReadToEnd(), Output);
         }
     }
 }

--- a/tests/DbEx.Test/Resources/MySqlInspect.md
+++ b/tests/DbEx.Test/Resources/MySqlInspect.md
@@ -1,0 +1,53 @@
+# DATABASE INSPECT (provider: MySQL)
+
+This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
+
+**Note**: This following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+
+## UNKNOWN - Exists: No
+
+## GENDER - Exists: Yes
+
+- Schema: 
+- Name: gender
+- Qualified Name: `gender`
+- Table or View: Table
+- Reference Data: Yes
+
+### Columns
+
+| Column     | Type         | Null | Default | PK  | Identity | Computed | Unique |
+|------------|--------------|------|---------|-----|----------|----------|--------|
+| gender_id  | INT          | No   |         | Yes | Yes      | No       | No     |
+| code       | VARCHAR(50)  | No   |         | No  | No       | No       | Yes    |
+| text       | VARCHAR(256) | No   |         | No  | No       | No       | No     |
+| created_by | VARCHAR(50)  | Yes  |         | No  | No       | No       | No     |
+| created_on | DATETIME     | Yes  |         | No  | No       | No       | No     |
+| updated_by | VARCHAR(50)  | Yes  |         | No  | No       | No       | No     |
+| updated_on | DATETIME     | Yes  |         | No  | No       | No       | No     |
+
+## CONTACT - Exists: Yes
+
+- Schema: 
+- Name: contact
+- Qualified Name: `contact`
+- Table or View: Table
+- Reference Data: No
+
+### Columns
+
+| Column            | Type         | Null | Default | PK  | Identity | Computed | Unique |
+|-------------------|--------------|------|---------|-----|----------|----------|--------|
+| contact_id        | INT          | No   |         | Yes | Yes      | No       | No     |
+| name              | VARCHAR(200) | No   |         | No  | No       | No       | No     |
+| phone             | VARCHAR(15)  | Yes  |         | No  | No       | No       | No     |
+| date_of_birth     | DATE         | Yes  |         | No  | No       | No       | No     |
+| contact_type_id   | INT          | No   | 1       | No  | No       | No       | No     |
+| gender_id         | INT          | Yes  |         | No  | No       | No       | No     |
+| notes             | TEXT         | Yes  |         | No  | No       | No       | No     |
+| created_by        | VARCHAR(50)  | Yes  |         | No  | No       | No       | No     |
+| created_on        | DATETIME     | Yes  |         | No  | No       | No       | No     |
+| updated_by        | VARCHAR(50)  | Yes  |         | No  | No       | No       | No     |
+| updated_on        | DATETIME     | Yes  |         | No  | No       | No       | No     |
+| contact_type_code | VARCHAR(50)  | Yes  |         | No  | No       | No       | No     |
+

--- a/tests/DbEx.Test/Resources/MySqlInspect.md
+++ b/tests/DbEx.Test/Resources/MySqlInspect.md
@@ -2,7 +2,7 @@
 
 This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
 
-**Note**: This following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+**Noet**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
 
 ## UNKNOWN - Exists: No
 

--- a/tests/DbEx.Test/Resources/MySqlInspect.md
+++ b/tests/DbEx.Test/Resources/MySqlInspect.md
@@ -2,7 +2,7 @@
 
 This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
 
-**Noet**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+**Note**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
 
 ## UNKNOWN - Exists: No
 

--- a/tests/DbEx.Test/Resources/PostgresInspect.md
+++ b/tests/DbEx.Test/Resources/PostgresInspect.md
@@ -2,7 +2,7 @@
 
 This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
 
-**Noet**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+**Note**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
 
 ## PUBLIC.UNKNOWN - Exists: No
 

--- a/tests/DbEx.Test/Resources/PostgresInspect.md
+++ b/tests/DbEx.Test/Resources/PostgresInspect.md
@@ -1,0 +1,55 @@
+# DATABASE INSPECT (provider: Postgres)
+
+This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
+
+**Note**: This following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+
+## PUBLIC.UNKNOWN - Exists: No
+
+## PUBLIC.GENDER - Exists: Yes
+
+- Schema: public
+- Name: gender
+- Qualified Name: "public"."gender"
+- Table or View: Table
+- Reference Data: Yes
+
+### Columns
+
+| Column     | Type                     | Null | Default | PK  | Identity | Computed | Unique |
+|------------|--------------------------|------|---------|-----|----------|----------|--------|
+| gender_id  | INTEGER                  | No   |         | Yes | Yes      | No       | No     |
+| code       | CHARACTER VARYING(50)    | No   |         | No  | No       | No       | Yes    |
+| text       | CHARACTER VARYING(256)   | No   |         | No  | No       | No       | No     |
+| created_by | CHARACTER VARYING(50)    | Yes  |         | No  | No       | No       | No     |
+| created_on | TIMESTAMP WITH TIME ZONE | Yes  |         | No  | No       | No       | No     |
+| updated_by | CHARACTER VARYING(50)    | Yes  |         | No  | No       | No       | No     |
+| updated_on | TIMESTAMP WITH TIME ZONE | Yes  |         | No  | No       | No       | No     |
+| xmin       | XID                      | No   |         | No  | No       | Yes      | No     |
+
+## PUBLIC.CONTACT - Exists: Yes
+
+- Schema: public
+- Name: contact
+- Qualified Name: "public"."contact"
+- Table or View: Table
+- Reference Data: No
+
+### Columns
+
+| Column            | Type                     | Null | Default | PK  | Identity | Computed | Unique |
+|-------------------|--------------------------|------|---------|-----|----------|----------|--------|
+| contact_id        | INTEGER                  | No   |         | Yes | Yes      | No       | No     |
+| name              | CHARACTER VARYING(200)   | No   |         | No  | No       | No       | No     |
+| phone             | CHARACTER VARYING(15)    | Yes  |         | No  | No       | No       | No     |
+| date_of_birth     | DATE                     | Yes  |         | No  | No       | No       | No     |
+| contact_type_id   | INTEGER                  | No   | 1       | No  | No       | No       | No     |
+| gender_id         | INTEGER                  | Yes  |         | No  | No       | No       | No     |
+| notes             | TEXT                     | Yes  |         | No  | No       | No       | No     |
+| created_by        | CHARACTER VARYING(50)    | Yes  |         | No  | No       | No       | No     |
+| created_on        | TIMESTAMP WITH TIME ZONE | Yes  |         | No  | No       | No       | No     |
+| updated_by        | CHARACTER VARYING(50)    | Yes  |         | No  | No       | No       | No     |
+| updated_on        | TIMESTAMP WITH TIME ZONE | Yes  |         | No  | No       | No       | No     |
+| contact_type_code | CHARACTER VARYING(50)    | Yes  |         | No  | No       | No       | No     |
+| xmin              | XID                      | No   |         | No  | No       | Yes      | No     |
+

--- a/tests/DbEx.Test/Resources/PostgresInspect.md
+++ b/tests/DbEx.Test/Resources/PostgresInspect.md
@@ -2,7 +2,7 @@
 
 This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
 
-**Note**: This following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+**Noet**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
 
 ## PUBLIC.UNKNOWN - Exists: No
 

--- a/tests/DbEx.Test/Resources/SqlServerInspect.md
+++ b/tests/DbEx.Test/Resources/SqlServerInspect.md
@@ -2,7 +2,7 @@
 
 This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
 
-**Note**: This following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+**Noet**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
 
 ## TEST.UNKNOWN - Exists: No
 

--- a/tests/DbEx.Test/Resources/SqlServerInspect.md
+++ b/tests/DbEx.Test/Resources/SqlServerInspect.md
@@ -2,7 +2,7 @@
 
 This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
 
-**Noet**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+**Note**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
 
 ## TEST.UNKNOWN - Exists: No
 

--- a/tests/DbEx.Test/Resources/SqlServerInspect.md
+++ b/tests/DbEx.Test/Resources/SqlServerInspect.md
@@ -1,0 +1,50 @@
+# DATABASE INSPECT (provider: SqlServer)
+
+This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
+
+**Note**: This following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.
+
+## TEST.UNKNOWN - Exists: No
+
+## TEST.GENDER - Exists: Yes
+
+- Schema: Test
+- Name: Gender
+- Qualified Name: [Test].[Gender]
+- Table or View: Table
+- Reference Data: Yes
+
+### Columns
+
+| Column    | Type           | Null | Default | PK  | Identity | Computed | Unique |
+|-----------|----------------|------|---------|-----|----------|----------|--------|
+| GenderId  | INT            | No   |         | Yes | Yes      | No       | No     |
+| Code      | NVARCHAR(50)   | No   |         | No  | No       | No       | Yes    |
+| Text      | VARCHAR(256)   | No   |         | No  | No       | No       | No     |
+| CreatedBy | NVARCHAR(250)  | Yes  |         | No  | No       | No       | No     |
+| CreatedOn | DATETIMEOFFSET | Yes  |         | No  | No       | No       | No     |
+| UpdatedBy | NVARCHAR(250)  | Yes  |         | No  | No       | No       | No     |
+| UpdatedOn | DATETIMEOFFSET | Yes  |         | No  | No       | No       | No     |
+
+## TEST.CONTACT - Exists: Yes
+
+- Schema: Test
+- Name: Contact
+- Qualified Name: [Test].[Contact]
+- Table or View: Table
+- Reference Data: No
+
+### Columns
+
+| Column          | Type          | Null | Default | PK  | Identity | Computed | Unique |
+|-----------------|---------------|------|---------|-----|----------|----------|--------|
+| ContactId       | INT           | No   |         | Yes | No       | No       | No     |
+| Name            | NVARCHAR(200) | No   |         | No  | No       | No       | No     |
+| Phone           | VARCHAR(15)   | Yes  |         | No  | No       | No       | No     |
+| DateOfBirth     | DATE          | Yes  |         | No  | No       | No       | No     |
+| ContactTypeId   | INT           | No   | ((1))   | No  | No       | No       | No     |
+| GenderId        | INT           | Yes  |         | No  | No       | No       | No     |
+| TenantId        | NVARCHAR(50)  | Yes  |         | No  | No       | No       | No     |
+| Notes           | NVARCHAR(MAX) | Yes  |         | No  | No       | No       | No     |
+| ContactTypeCode | NVARCHAR(50)  | Yes  |         | No  | No       | No       | No     |
+

--- a/tests/DbEx.Test/SqlServerMigrationTest.cs
+++ b/tests/DbEx.Test/SqlServerMigrationTest.cs
@@ -388,5 +388,26 @@ some other stuf", "blah"));
             Assert.That(ss.Schema, Is.EqualTo("Sec"));
             Assert.That(ss.Name, Is.EqualTo("fnGetUserHasPermission"));
         }
+
+        [Test]
+        public async Task SqlServerInspect()
+        {
+            var cs = UnitTest.GetConfig("DbEx_").GetConnectionString("ConsoleDb");
+            var l = UnitTest.GetLogger<SqlServerMigrationTest>();
+            var a = new MigrationArgs(MigrationCommand.Inspect, cs) { Logger = l };
+            a.Parameters.Add("Param0", "test");
+            a.Parameters.Add("Param1", "unknown");
+            a.Parameters.Add("Param2", "gender");
+            a.Parameters.Add("Param3", "CONTACT");
+
+            using var m = new SqlServerMigration(a);
+            var (Success, Output) = await m.MigrateAndLogAsync().ConfigureAwait(false);
+
+            Assert.IsTrue(Success);
+            Assert.IsTrue(Output.Length > 0);
+
+            using var sr = SqlServerMigration.GetRequiredResourcesStreamReader("SqlServerInspect.md", [typeof(SqlServerMigrationTest).Assembly]);
+            Assert.AreEqual(sr.ReadToEnd(), Output);
+        }
     }
 }


### PR DESCRIPTION
- *Enhancement:* Added new `MigrationCommand.Inspect` to inspect the specified database tables and outputs schema-based markdown to the console.
  - This is intended to be a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.
  - Command line execution is as: `dotnet run -- inspect schema table1 table2`