### PR TITLE
V3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 Represents the **NuGet** versions.
 
 ## v3.1.2
-- *Fixed:* Where a `DbException` occurs executing a command, only the exception message is now logged; not the full stack trace as this is misleading.
-- *Fixed:* Prior to executing a command that requires the database, its existence will be checked first and an appropriate error returned where not found.
+- *Fixed:* Where a `DbException` occurs executing a command, only the exception message is now logged; not the full stack trace as this is misleading (experience improvement).
+- *Fixed:* Prior to executing a command that requires the database, its existence will be checked first and an appropriate error emitted where not found (experience improvement).
+- *Fixed* Unify the default primary key type as a string for the create and reference-data scripts across the database providers (consistency correction).
 
 ## v3.1.1
 - *Fixed:* Updated `OnRamp` to version `2.2.5` which emits JSON schema arrays allowing null values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.1.2
+- *Fixed:* Where a `DbException` occurs executing a command, only the exception message is now logged; not the full stack trace as this is misleading.
+- *Fixed:* Prior to executing a command that requires the database, its existence will be checked first and an appropriate error returned where not found.
+
 ## v3.1.1
 - *Fixed:* Updated `OnRamp` to version `2.2.5` which emits JSON schema arrays allowing null values.
 - *Fixed:* Updated `DataParser` to support JSON arrays allowing null values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Represents the **NuGet** versions.
 ## v3.1.2
 - *Fixed:* Where a `DbException` occurs executing a command, only the exception message is now logged; not the full stack trace as this is misleading (experience improvement).
 - *Fixed:* Prior to executing a command that requires the database, its existence will be checked first and an appropriate error emitted where not found (experience improvement).
-- *Fixed* Unify the default primary key type as a string for the create and reference-data scripts across the database providers (consistency correction).
+- *Fixed:* Unify the default primary key type as a string for the create and reference-data scripts across the database providers (consistency correction).
 
 ## v3.1.1
 - *Fixed:* Updated `OnRamp` to version `2.2.5` which emits JSON schema arrays allowing null values.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>3.1.1</Version>
+    <Version>3.1.2</Version>
     <LangVersion>preview</LangVersion>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>

--- a/src/DbEx.MySql/Resources/ScriptCreate_mysql.hbs
+++ b/src/DbEx.MySql/Resources/ScriptCreate_mysql.hbs
@@ -6,7 +6,7 @@
 START TRANSACTION;
 
 CREATE TABLE `{{lookup Parameters 'Param1'}}` (
-  `{{lookup Parameters 'Param1'}}_id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `{{lookup Parameters 'Param1'}}_id` VARCHAR(50) NOT NULL PRIMARY KEY,
   -- `code` VARCHAR(50) NULL UNIQUE,
   -- `text` VARCHAR(250) NULL,
   -- `bool` BOOL NULL,

--- a/src/DbEx.MySql/Resources/ScriptRefData_mysql.hbs
+++ b/src/DbEx.MySql/Resources/ScriptRefData_mysql.hbs
@@ -6,7 +6,7 @@
 START TRANSACTION;
 
 CREATE TABLE `{{lookup Parameters 'Param1'}}` (
-  `{{lookup Parameters 'Param1'}}_id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `{{lookup Parameters 'Param1'}}_id` VARCHAR(50) NOT NULL PRIMARY KEY,
   `code` VARCHAR(50) NOT NULL UNIQUE,
   `text` VARCHAR(250) NULL,
   `is_active` BOOL NULL,

--- a/src/DbEx.Postgres/Resources/ScriptCreate_pgsql.hbs
+++ b/src/DbEx.Postgres/Resources/ScriptCreate_pgsql.hbs
@@ -5,7 +5,7 @@
 -- Create table: "{{lookup Parameters 'Param1'}}"."{{lookup Parameters 'Param2'}}"
 
 CREATE TABLE "{{lookup Parameters 'Param1'}}"."{{lookup Parameters 'Param2'}}" (
-  "{{lookup Parameters 'Param2'}}_id" SERIAL PRIMARY KEY,
+  "{{lookup Parameters 'Param2'}}_id" VARCHAR(50) NOT NULL PRIMARY KEY,
   -- "code" VARCHAR(50) NULL UNIQUE,
   -- "text" VARCHAR(250) NULL,
   -- "bool" BOOLEAN NULL,

--- a/src/DbEx.Postgres/Resources/ScriptRefData_pgsql.hbs
+++ b/src/DbEx.Postgres/Resources/ScriptRefData_pgsql.hbs
@@ -5,7 +5,7 @@
 -- Create Reference Data table: "{{lookup Parameters 'Param1'}}"."{{lookup Parameters 'Param2'}}"
 
 CREATE TABLE "{{lookup Parameters 'Param1'}}"."{{lookup Parameters 'Param2'}}" (
-  "{{lookup Parameters 'Param2'}}_id" SERIAL PRIMARY KEY,
+  "{{lookup Parameters 'Param2'}}_id" VARCHAR(50) NOT NULL PRIMARY KEY,
   "code" VARCHAR(50) NOT NULL UNIQUE,
   "text" VARCHAR(250) NULL,
   "is_active" BOOLEAN NULL,

--- a/src/DbEx.SqlServer/Resources/ScriptCreate_sql.hbs
+++ b/src/DbEx.SqlServer/Resources/ScriptCreate_sql.hbs
@@ -7,7 +7,7 @@
 BEGIN TRANSACTION
 
 CREATE TABLE [{{lookup Parameters 'Param1'}}].[{{lookup Parameters 'Param2'}}] (
-  [{{lookup Parameters 'Param2'}}Id] UNIQUEIDENTIFIER NOT NULL DEFAULT (NEWSEQUENTIALID()) PRIMARY KEY,
+  [{{lookup Parameters 'Param2'}}Id] NVARCHAR(50) NOT NULL PRIMARY KEY,
   -- [Code] NVARCHAR(50) NULL UNIQUE,
   -- [Text] NVARCHAR(250) NULL,
   -- [Bool] BIT NULL,

--- a/src/DbEx.SqlServer/Resources/ScriptRefData_sql.hbs
+++ b/src/DbEx.SqlServer/Resources/ScriptRefData_sql.hbs
@@ -7,7 +7,7 @@
 BEGIN TRANSACTION
 
 CREATE TABLE [{{lookup Parameters 'Param1'}}].[{{lookup Parameters 'Param2'}}] (
-  [{{lookup Parameters 'Param2'}}Id] UNIQUEIDENTIFIER NOT NULL DEFAULT (NEWSEQUENTIALID()) PRIMARY KEY,
+  [{{lookup Parameters 'Param2'}}Id] NVARCHAR(50) NOT NULL PRIMARY KEY,
   [Code] NVARCHAR(50) NOT NULL UNIQUE,
   [Text] NVARCHAR(250) NULL,
   [IsActive] BIT NULL,

--- a/src/DbEx/Migration/Data/DataParserArgs.cs
+++ b/src/DbEx/Migration/Data/DataParserArgs.cs
@@ -1,7 +1,7 @@
 ﻿namespace DbEx.Migration.Data;
 
 /// <summary>
-/// Represents the <see cref="DataParser"/> arguments.
+/// Represents the <see cref="DataParser"/> arguments used for identifying, parsing and loading data from embedded resource files; and also for providing runtime parameters and defaults to support the parsing and loading process.
 /// </summary>
 public class DataParserArgs
 {
@@ -133,6 +133,29 @@ public class DataParserArgs
     public bool ReplaceShorthandGuids { get; set; } = true;
 
     /// <summary>
+    /// Gets the list of named resource files to load.
+    /// </summary>
+    /// <remarks>Empty by default meaning all embedded resources will be considered; otherwise, only the specified resource file names will be considered (case-sensitive). The specified name(s) must match (ends with) the discovered resource file name(s); therefore, they must also include the file suffix.</remarks>
+    public Dictionary<Assembly, string[]> NamedResources { get; private set; } = [];
+
+    /// <summary>
+    /// Adds the specified resource file names to the <see cref="NamedResources"/> list.
+    /// </summary>
+    /// <typeparam name="TResource">The type whose underlying <see cref="Type.Assembly"/> is used as the <see cref="NamedResources"/> assembly reference.</typeparam>
+    /// <param name="resourceFileNames">The resource file names to add.</param>
+    /// <returns>The <see cref="DataParserArgs"/> to support fluent-style method-chaining.</returns>
+    public DataParserArgs AddNamed<TResource>(params string[] resourceFileNames)
+    {
+        if (resourceFileNames == null || resourceFileNames.Length == 0)
+            throw new ArgumentException("Resource file names cannot be null or empty.", nameof(resourceFileNames));
+
+        if (!NamedResources.TryAdd(typeof(TResource).Assembly, resourceFileNames))
+            throw new ArgumentException("Resource file names for the specified assembly have already been added.", nameof(resourceFileNames));
+
+        return this;
+    }
+
+    /// <summary>
     /// Copy and replace from <paramref name="args"/>.
     /// </summary>
     /// <param name="args">The <see cref="DataParserArgs"/> to copy from.</param>
@@ -157,5 +180,6 @@ public class DataParserArgs
         TableNameMappings.Clear();
         args.TableNameMappings.ForEach(x => TableNameMappings.Add(x.Key.ParsedSchema, x.Key.ParsedTable, x.Value.Schema, x.Value.Table, x.Value.ColumnMappings));
         ReplaceShorthandGuids = args.ReplaceShorthandGuids;
+        NamedResources = args.NamedResources;
     }
 }

--- a/src/DbEx/Migration/Data/DataParserArgs.cs
+++ b/src/DbEx/Migration/Data/DataParserArgs.cs
@@ -180,6 +180,8 @@ public class DataParserArgs
         TableNameMappings.Clear();
         args.TableNameMappings.ForEach(x => TableNameMappings.Add(x.Key.ParsedSchema, x.Key.ParsedTable, x.Value.Schema, x.Value.Table, x.Value.ColumnMappings));
         ReplaceShorthandGuids = args.ReplaceShorthandGuids;
-        NamedResources = args.NamedResources;
+        NamedResources.Clear();
+        foreach (var nr in args.NamedResources)
+            NamedResources.Add(nr.Key, nr.Value.ToArray());
     }
 }

--- a/src/DbEx/Migration/DatabaseMigrationBase.cs
+++ b/src/DbEx/Migration/DatabaseMigrationBase.cs
@@ -179,6 +179,14 @@ public abstract class DatabaseMigrationBase : IDisposable
         if (!await CommandExecuteAsync(MigrationCommand.Create, "DATABASE CREATE: Checking database existence and creating where not found...", DatabaseCreateAsync, null, cancellationToken).ConfigureAwait(false))
             return false;
 
+        // Check database existence as there is no point continuing if the database was not created successfully or does not exist for some reason.
+        var exists = await DatabaseExistsAsync(cancellationToken).ConfigureAwait(false);
+        if (!exists)
+        {
+            Logger.LogError("{Content}", $"Database '{DatabaseName}' does not exist; cannot continue with command.");
+            return false;
+        }
+
         // Database migration scripts.
         if (!await CommandExecuteAsync(MigrationCommand.Migrate, "DATABASE MIGRATE: Migrating the database...", DatabaseMigrateAsync, null, cancellationToken).ConfigureAwait(false))
             return false;
@@ -314,6 +322,14 @@ public abstract class DatabaseMigrationBase : IDisposable
             Logger.LogInformation("{Content}", string.Empty);
             Logger.LogInformation("{Content}", $"Complete. [{sw.Elapsed.TotalMilliseconds}ms{summary?.Invoke() ?? string.Empty}]");
             return true;
+        }
+        catch (DbException dbex)
+        {
+            // DbException is the base exception for database related exceptions across ADO.NET providers (e.g. SqlException for SQL Server, NpgsqlException for PostgreSQL, MySqlException for MySQL etc.)
+            // and as such is the most appropriate to catch here to log any database related errors that may occur during the execution of the command. No stacktrace is required for these types of exceptions
+            // as the message will contain the relevant details of the error that occurred.
+            Logger.LogError("{Content}", $"A database error occurred: {dbex.Message}");
+            return false;
         }
         catch (Exception ex)
         {
@@ -797,7 +813,9 @@ public abstract class DatabaseMigrationBase : IDisposable
                         || rn.EndsWith(".json", StringComparison.InvariantCultureIgnoreCase) || rn.EndsWith(".jsn", StringComparison.InvariantCultureIgnoreCase))))
                         continue;
 
-                    list.Add((ass.Assembly, rn));
+                    // Filter on named resources where specified; otherwise, include by default.
+                    if (!Args.DataParserArgs.NamedResources.TryGetValue(ass.Assembly, out var namedResources) || namedResources.Any(nr => rn.EndsWith(nr, StringComparison.InvariantCulture)))
+                        list.Add((ass.Assembly, rn));
                 }
             }
         }
@@ -1055,17 +1073,19 @@ public abstract class DatabaseMigrationBase : IDisposable
     {
         Logger.LogInformation("{Content}", $"# DATABASE INSPECT (provider: {Provider})");
         Logger.LogInformation("{Content}", string.Empty);
+
+        // Ensure database exists before trying to query the schema.
+        var dbExists = await DatabaseExistsAsync(cancellationToken).ConfigureAwait(false);
+        if (!dbExists)
+        {
+            Logger.LogWarning("{Content}", $"Database '{DatabaseName}' does not exist; as such there is no schema to inspect.");
+            return false;
+        }
+
         Logger.LogInformation("{Content}", "This command is intended to be used as a quick-and-easy way to inspect the inferred database schema based on the current database state. It is not intended to be a full-blown documentation generator; therefore, the output is limited to basic markdown tables that show the column names, data types, nullability, and primary key status for the specified tables. The markdown output can be copied and pasted into any markdown viewer or editor for further formatting or documentation purposes.");
         Logger.LogInformation("{Content}", string.Empty);
         Logger.LogInformation("{Content}", "**Note**: The following is based on querying the database system tables/views; it may not be 100% accurate. Always refer to the actual database for the source of truth.");
         Logger.LogInformation("{Content}", string.Empty);
-
-        var dbExists = await DatabaseExistsAsync(cancellationToken).ConfigureAwait(false);
-        if (!dbExists)
-        {
-            Logger.LogWarning("{Content}", $"Database does not exist; as such there is no schema to inspect."); 
-            return false;
-        }
 
         if (parameters is null || parameters.Count == 0)
             return true;
@@ -1097,6 +1117,9 @@ public abstract class DatabaseMigrationBase : IDisposable
         return true;
     }
 
+    /// <summary>
+    /// Outputs the markdown for the specified table schema.
+    /// </summary>
     private void InspectTableMarkdown(string? schema, string name, DbSchema.DbTableSchema? table)
     {
         Logger.LogInformation("{Content}", $"## {(string.IsNullOrEmpty(schema) ? "" : $"{schema.ToUpperInvariant()}.")}{name.ToUpperInvariant()} - Exists: {(table != null ? "Yes" : "No")}");

--- a/src/DbEx/Templates/EfModelBuilder_cs.hbs
+++ b/src/DbEx/Templates/EfModelBuilder_cs.hbs
@@ -10,9 +10,7 @@ namespace {{Root.DotNetDataEfRepositoriesNamespace}};
 
 public partial class {{Domain}}DbContext
 {
-    /// <summary>
-    /// Adds the generated models to the <paramref name="modelBuilder"/>.
-    /// </summary>
+    /// <summary>Adds the generated models to the <paramref name="modelBuilder"/>.</summary>
     /// <param name="modelBuilder">The <see cref="Microsoft.EntityFrameworkCore.ModelBuilder"/>.</param>
     public void AddGeneratedModels(Microsoft.EntityFrameworkCore.ModelBuilder modelBuilder)
     {

--- a/src/DbEx/Templates/EfModel_cs.hbs
+++ b/src/DbEx/Templates/EfModel_cs.hbs
@@ -8,18 +8,14 @@
 
 namespace {{Root.DotNetDataEfModelsNamespace}};
 
-/// <summary>
-/// Persistence model representing the '<c>{{DbTable.QualifiedName}}</c>' database table.
-/// </summary>
+/// <summary>Persistence model representing the '<c>{{DbTable.QualifiedName}}</c>' database table.</summary>
 public partial class {{EfModelName}}
 {
 {{#each Columns}}
   {{#unless @first}}
 
   {{/unless}}
-    /// <summary>
-    /// Gets or sets the value of the '<c>{{DbColumn.Name}}</c>' column (<c>{{DbColumn.SqlType}}</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>{{DbColumn.Name}}</c>' column (<c>{{DbColumn.SqlType}}</c>).</summary>
   {{#if DbColumn.IsPrimaryKey}}
     /// <remarks>This is {{#ifeq Parent.DbTable.PrimaryKeyColumns.Count 1}}the primary key{{else}}part of the primary key{{/ifeq}}.</remarks>
   {{/if}}

--- a/tests/DbEx.Test.Console/Program.cs
+++ b/tests/DbEx.Test.Console/Program.cs
@@ -9,11 +9,11 @@ namespace DbEx.Test.Console
             .Create<Program>("Data Source=127.0.0.1,1433;Initial Catalog=DbEx.Console;User id=sa;Password=yourStrong(!)Password;TrustServerCertificate=true")
             .Configure(c =>
             {
-                //c.Args.AddAssembly<DbEx.Test.OutboxConsole.Program>("Data", "Data2");
                 c.Args.AddSchemaOrder("Test", "Outbox");
                 c.Args.IncludeExtendedSchemaScripts();
                 c.Args.DataParserArgs.Parameter("DefaultName", "Bazza")
                                      .Parameter("jane_name", "Jane")
+                                     //.AddNamed<Program>("Data.yaml")
                                      .RefDataColumnDefault("SortOrder", i => i)
                                      .ColumnDefault("*", "*", "TenantId", _ => "test-tenant")
                                      .TableNameMappings.Add("XTest", "XContactType", "Test", "ContactType", new() { { "XNumber", "Number" } })

--- a/tests/DbEx.Test.Console/Properties/launchSettings.json
+++ b/tests/DbEx.Test.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DbEx.Test.Console": {
       "commandName": "Project",
-      "commandLineArgs": "inspect test gender contact"
+      "commandLineArgs": "dropandall"
     }
   }
 }

--- a/tests/DbEx.Test.Empty/Persistence/Contact.g.cs
+++ b/tests/DbEx.Test.Empty/Persistence/Contact.g.cs
@@ -8,55 +8,35 @@
 
 namespace DbEx.Test.Empty.Persistence;
 
-/// <summary>
-/// Persistence model representing the '<c>[Test].[Contact]</c>' database table.
-/// </summary>
+/// <summary>Persistence model representing the '<c>[Test].[Contact]</c>' database table.</summary>
 public partial class Contact
 {
-    /// <summary>
-    /// Gets or sets the value of the '<c>ContactId</c>' column (<c>INT</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>ContactId</c>' column (<c>INT</c>).</summary>
     /// <remarks>This is the primary key.</remarks>
     public int ContactId { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>Name</c>' column (<c>NVARCHAR(200)</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>Name</c>' column (<c>NVARCHAR(200)</c>).</summary>
     public string Name { get; set; } = default!;
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>Phone</c>' column (<c>VARCHAR(15) NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>Phone</c>' column (<c>VARCHAR(15) NULL</c>).</summary>
     public string? Phone { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>DateOfBirth</c>' column (<c>DATE NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>DateOfBirth</c>' column (<c>DATE NULL</c>).</summary>
     public DateOnly? DateOfBirth { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>ContactTypeId</c>' column (<c>INT</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>ContactTypeId</c>' column (<c>INT</c>).</summary>
     public int ContactTypeId { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>GenderId</c>' column (<c>INT NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>GenderId</c>' column (<c>INT NULL</c>).</summary>
     public int? GenderId { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>TenantId</c>' column (<c>NVARCHAR(50) NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>TenantId</c>' column (<c>NVARCHAR(50) NULL</c>).</summary>
     public string? TenantId { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>Notes</c>' column (<c>NVARCHAR(MAX) NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>Notes</c>' column (<c>NVARCHAR(MAX) NULL</c>).</summary>
     public string? Notes { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>ContactTypeCode</c>' column (<c>NVARCHAR(50) NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>ContactTypeCode</c>' column (<c>NVARCHAR(50) NULL</c>).</summary>
     public string? ContactTypeCode { get; set; }
 }
 

--- a/tests/DbEx.Test.Empty/Persistence/Person.g.cs
+++ b/tests/DbEx.Test.Empty/Persistence/Person.g.cs
@@ -8,50 +8,32 @@
 
 namespace DbEx.Test.Empty.Persistence;
 
-/// <summary>
-/// Persistence model representing the '<c>[Test].[Person]</c>' database table.
-/// </summary>
+/// <summary>Persistence model representing the '<c>[Test].[Person]</c>' database table.</summary>
 public partial class Person
 {
-    /// <summary>
-    /// Gets or sets the value of the '<c>PersonId</c>' column (<c>UNIQUEIDENTIFIER</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>PersonId</c>' column (<c>UNIQUEIDENTIFIER</c>).</summary>
     /// <remarks>This is the primary key.</remarks>
     public Guid PersonId { get; set; } = Guid.NewGuid();
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>Name</c>' column (<c>NVARCHAR(200)</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>Name</c>' column (<c>NVARCHAR(200)</c>).</summary>
     public string Name { get; set; } = default!;
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>NicknamesJson</c>' column (<c>NVARCHAR(500) NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>NicknamesJson</c>' column (<c>NVARCHAR(500) NULL</c>).</summary>
     public string? NicknamesJson { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>AddressJson</c>' column (<c>NVARCHAR(500) NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>AddressJson</c>' column (<c>NVARCHAR(500) NULL</c>).</summary>
     public Persistence.Address? Address { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>CreatedBy</c>' column (<c>NVARCHAR(250) NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>CreatedBy</c>' column (<c>NVARCHAR(250) NULL</c>).</summary>
     public string? CreatedBy { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>CreatedOn</c>' column (<c>DATETIMEOFFSET NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>CreatedOn</c>' column (<c>DATETIMEOFFSET NULL</c>).</summary>
     public DateTimeOffset? CreatedOn { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>UpdatedBy</c>' column (<c>NVARCHAR(250) NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>UpdatedBy</c>' column (<c>NVARCHAR(250) NULL</c>).</summary>
     public string? UpdatedBy { get; set; }
 
-    /// <summary>
-    /// Gets or sets the value of the '<c>UpdatedOn</c>' column (<c>DATETIMEOFFSET NULL</c>).
-    /// </summary>
+    /// <summary>Gets or sets the value of the '<c>UpdatedOn</c>' column (<c>DATETIMEOFFSET NULL</c>).</summary>
     public DateTimeOffset? UpdatedOn { get; set; }
 }
 

--- a/tests/DbEx.Test.Empty/Repositories/TestDbContext.g.cs
+++ b/tests/DbEx.Test.Empty/Repositories/TestDbContext.g.cs
@@ -10,9 +10,7 @@ namespace DbEx.Test.Empty.Repositories;
 
 public partial class TestDbContext
 {
-    /// <summary>
-    /// Adds the generated models to the <paramref name="modelBuilder"/>.
-    /// </summary>
+    /// <summary>Adds the generated models to the <paramref name="modelBuilder"/>.</summary>
     /// <param name="modelBuilder">The <see cref="Microsoft.EntityFrameworkCore.ModelBuilder"/>.</param>
     public void AddGeneratedModels(Microsoft.EntityFrameworkCore.ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
Fixed: Where a DbException occurs executing a command, only the exception message is now logged; not the full stack trace as this is misleading (experience improvement).
Fixed: Prior to executing a command that requires the database, its existence will be checked first and an appropriate error emitted where not found (experience improvement).
Fixed Unify the default primary key type as a string for the create and reference-data scripts across the database providers (consistency correction).